### PR TITLE
chore(docker): Add Github Actions to build and push Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,76 @@
+name: Build project, then Docker Image and publish to Github Artifact Registry
+
+on:
+  push:
+    # Publish semver tags as releases.
+    tags: ['v*.*.*']
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build from source to dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: yarn install
+      - run: yarn build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  docker:
+    name: Build Docker Image and publish to Github Artifact Registry
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ↙️ Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,7 +47,7 @@ jobs:
           path: dist
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -55,13 +55,13 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ COPY --chown=node:node package.json /home/node/app/package.json
 COPY --chown=node:node yarn.lock /home/node/app/yarn.lock
 COPY --chown=node:node dist /home/node/app/dist
 
-RUN yarn install --production
+RUN yarn install
 
 CMD ["node", "dist/src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18
+
+RUN mkdir -p /home/node/app \
+    && chown -R node:node /home/node/app
+
+WORKDIR /home/node/app
+
+ENV NODE_ENV=production
+
+EXPOSE 3000
+
+USER node
+
+COPY --chown=node:node package.json /home/node/app/package.json
+COPY --chown=node:node yarn.lock /home/node/app/yarn.lock
+COPY --chown=node:node dist /home/node/app/dist
+
+RUN yarn install --production
+
+CMD ["node", "dist/src/index.js"]


### PR DESCRIPTION
Actions are doing (only for v*.*.* tags):
- Building the project into dist
- Building the docker image by copying dist + installing dependencies
- Pushing the tag image to Github Artifact Repository

https://github.com/ManoManoTech/homer/pkgs/container/homer