### PR TITLE
Setup code coverage with codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,4 +15,11 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn lint
-      - run: yarn test
+      - run: yarn test --coverage
+
+      - name: "Upload to Codecov"
+        uses: "codecov/codecov-action@v4"
+        with:
+          directory: coverage
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
We will have to provide a codecov token for builds. The token will not be used for PRs from forks.