### PR TITLE
fix: yarn start

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
+API_BASE_PATH=/api/v1/homer
 EMAIL_DOMAINS=my-domain.com,ext.my-domain.com
 GITLAB_SECRET=GITLAB_SECRET
 GITLAB_TOKEN=GITLAB_TOKEN


### PR DESCRIPTION
The command `yarn start` is broken since last commit. This MR is fixing this issue for the development mode  

Here is the details about the issue
```
ERROR (43528):
    message: "Environment variable API_BASE_PATH not found"
```