### PR TITLE
chore: Log the errors when the project release configuration file is not valid.

### DIFF
--- a/src/release/utils/configBuilder.ts
+++ b/src/release/utils/configBuilder.ts
@@ -52,7 +52,7 @@ export async function buildProjectReleaseConfigs(
   releaseTagManagers: Record<string, ReleaseTagManager>
 ) {
   if (!validateProjectReleaseConfig(configs)) {
-    logger.error(`The config file validation failed : ${validateProjectReleaseConfig.errors}`);
+    logger.error({errors : validateProjectReleaseConfig.errors}, 'The config file validation failed');
     throw new Error(
       'The config file should contain an array of valid project configurations'
     );

--- a/src/release/utils/configBuilder.ts
+++ b/src/release/utils/configBuilder.ts
@@ -7,6 +7,7 @@ import type {
   ProjectConfigJSON,
 } from '../typings/ProjectReleaseConfig';
 import type { ReleaseTagManager } from '../typings/ReleaseTagManager';
+import { logger } from '@/core/services/logger';
 
 // only one Ajv instance should be used across all the application
 // maybe a singleton class would be better
@@ -51,6 +52,7 @@ export async function buildProjectReleaseConfigs(
   releaseTagManagers: Record<string, ReleaseTagManager>
 ) {
   if (!validateProjectReleaseConfig(configs)) {
+    logger.error(`The config file validation failed : ${validateProjectReleaseConfig.errors}`);
     throw new Error(
       'The config file should contain an array of valid project configurations'
     );

--- a/src/release/utils/configBuilder.ts
+++ b/src/release/utils/configBuilder.ts
@@ -1,13 +1,13 @@
 import type { JSONSchemaType } from 'ajv';
 import Ajv from 'ajv';
 import ReleasePluginManager from '@/core/pluginManager/ReleasePluginManager';
+import { logger } from '@/core/services/logger';
 import type {
   ProjectConfigurationsJSON,
   ProjectReleaseConfig,
   ProjectConfigJSON,
 } from '../typings/ProjectReleaseConfig';
 import type { ReleaseTagManager } from '../typings/ReleaseTagManager';
-import { logger } from '@/core/services/logger';
 
 // only one Ajv instance should be used across all the application
 // maybe a singleton class would be better


### PR DESCRIPTION
# What 

Add an error log when the configuration file validation fails.

# Why

Currently if the configuration file is invalid, the log is just `The config file should contain an array of valid project configurations` which doesn't really help.