### PR TITLE
fix(deleted-project): Handle deleted Gitlab projects gracefully in project list and changelog

### DIFF
--- a/__tests__/project/listProjects.test.ts
+++ b/__tests__/project/listProjects.test.ts
@@ -26,8 +26,15 @@ describe('project > listProjects', () => {
       channelId,
       projectId: projectFixture.id + 1,
     });
+    await addProjectToChannel({
+      channelId,
+      projectId: projectFixture.id + 2,
+    });
+
     mockGitlabCall(`/projects/${projectFixture.id}`, projectFixture);
     mockGitlabCall(`/projects/${projectFixture.id + 1}`, projectFixture);
+    // This project will be removed from the list because it doesn't exist
+    mockGitlabCall(`/projects/${projectFixture.id + 2}`, {});
 
     // When
     const response = await fetch('/api/v1/homer/command', {

--- a/src/changelog/buildChangelogModalView.ts
+++ b/src/changelog/buildChangelogModalView.ts
@@ -28,7 +28,7 @@ export async function buildChangelogModalView({
           try {
             return await fetchProjectById(Number(dataProject.projectId));
           } catch (error) {
-            logger.warn(
+            logger.error(
               `Failed to fetch project ${dataProject.projectId}:`,
               error
             );

--- a/src/project/commands/list/listProjectsRequestHandler.ts
+++ b/src/project/commands/list/listProjectsRequestHandler.ts
@@ -2,6 +2,7 @@ import type { Response } from 'express';
 import { HTTP_STATUS_NO_CONTENT } from '@/constants';
 import { getProjectsByChannelId } from '@/core/services/data';
 import { fetchProjectById } from '@/core/services/gitlab';
+import { logger } from '@/core/services/logger';
 import { slackBotWebClient } from '@/core/services/slack';
 import type { GitlabProjectDetails } from '@/core/typings/GitlabProject';
 import type {
@@ -20,11 +21,20 @@ export async function listProjectsRequestHandler(
 
   const { channel_id, user_id } = req.body as SlackSlashCommandResponse;
   const dataProjects = await getProjectsByChannelId(channel_id);
-  const projects = (
+  const projects: GitlabProjectDetails[] = (
     await Promise.all(
-      dataProjects.map(async ({ projectId }) => fetchProjectById(projectId))
+      dataProjects.map(async ({ projectId }) => {
+        try {
+          return await fetchProjectById(projectId);
+        } catch (error) {
+          logger.warn(`Failed to fetch project ${projectId}:`, error);
+          return null;
+        }
+      })
     )
-  ).sort((a, b) => a.path_with_namespace.localeCompare(b.path_with_namespace));
+  )
+    .filter((project): project is GitlabProjectDetails => project !== null)
+    .sort((a, b) => a.path_with_namespace.localeCompare(b.path_with_namespace));
 
   const projectsParts: GitlabProjectDetails[][] = [];
 

--- a/src/project/commands/list/listProjectsRequestHandler.ts
+++ b/src/project/commands/list/listProjectsRequestHandler.ts
@@ -27,7 +27,7 @@ export async function listProjectsRequestHandler(
         try {
           return await fetchProjectById(projectId);
         } catch (error) {
-          logger.warn(`Failed to fetch project ${projectId}:`, error);
+          logger.error(`Failed to fetch project ${projectId}:`, error);
           return null;
         }
       })


### PR DESCRIPTION
# What

Previously, when trying to fetch projects that existed in our database but were 
deleted from Gitlab, the project list and changelog modal commands would fail 
entirely. This was because Promise.all would reject if any single project 
fetch failed.

# Fix

Changes:
- Added error handling around individual project fetches
- Filter out non-existing Gitlab projects instead of failing
- Ensures commands continue working even when some projects are inaccessible

# Conclusion 

This makes the system more resilient by allowing operations to continue even 
when some referenced projects no longer exist in Gitlab.