### PR TITLE
feat(mr-search): Target specific project from MR URL instead of searching all projects

### DIFF
--- a/__tests__/utils/mockBuildReviewMessageCalls.ts
+++ b/__tests__/utils/mockBuildReviewMessageCalls.ts
@@ -6,7 +6,14 @@ import { projectFixture } from '../__fixtures__/projectFixture';
 import { mockGitlabCall } from './mockGitlabCall';
 
 export function mockBuildReviewMessageCalls() {
-  const { iid, project_id } = mergeRequestFixture;
+  const { iid, project_id, web_url } = mergeRequestFixture;
+
+  const url = new URL(web_url);
+  const projectPath = url.pathname
+    .split('/')
+    .filter(Boolean)
+    .slice(0, -2)
+    .join('/');
 
   mockGitlabCall(
     `/projects/${project_id}/merge_requests/${iid}/approvals`,
@@ -14,6 +21,10 @@ export function mockBuildReviewMessageCalls() {
   );
   mockGitlabCall(
     `/projects/${project_id}/merge_requests/${iid}`,
+    mergeRequestDetailsFixture
+  );
+  mockGitlabCall(
+    `/projects/${encodeURIComponent(projectPath)}/merge_requests/${iid}`,
     mergeRequestDetailsFixture
   );
   mockGitlabCall(


### PR DESCRIPTION
# Why 

When searching for a merge request using its URL, we were unnecessarily querying all accessible projects,
even though the URL already contains the exact project path. This led to:
- Multiple unnecessary API calls (one per project)
- Potential timeouts on the Slack command due to high latency
- Wasted GitLab API rate limiting quota

# Improvements

- Extract the project path directly from the merge request URL
- Make a single API call to the specific project
- Eliminate the need to iterate through all projects

Example:
For URL: https://gitlab.com/group/project/-/merge_requests/123
- Before: Query MR #123 in every accessible project (~N API calls)
- After: Query MR #123 only in 'group/project' (1 API call)
