### PR TITLE
fix(search-mr): Fix the searchMergeRequestByUrl function to handle /-/ in the URL

### DIFF
--- a/__tests__/__fixtures__/mergeRequestDetailsFixture.ts
+++ b/__tests__/__fixtures__/mergeRequestDetailsFixture.ts
@@ -71,7 +71,7 @@ export const mergeRequestDetailsFixture: GitlabMergeRequestDetails = {
   force_remove_source_branch: false,
   allow_collaboration: false,
   allow_maintainer_to_push: false,
-  web_url: 'http://gitlab.example.com/my-group/my-project/merge_requests/1',
+  web_url: 'http://gitlab.example.com/my-group/my-project/-/merge_requests/1',
   references: {
     short: '!1',
     relative: '!1',

--- a/__tests__/__fixtures__/mergeRequestFixture.ts
+++ b/__tests__/__fixtures__/mergeRequestFixture.ts
@@ -72,7 +72,7 @@ export const mergeRequestFixture: GitlabMergeRequest = {
   force_remove_source_branch: false,
   allow_collaboration: false,
   allow_maintainer_to_push: false,
-  web_url: 'http://gitlab.example.com/my-group/my-project/merge_requests/1',
+  web_url: 'http://gitlab.example.com/my-group/my-project/-/merge_requests/1',
   references: {
     short: '!1',
     relative: 'my-group/my-project!1',

--- a/__tests__/release/createRelease.test.ts
+++ b/__tests__/release/createRelease.test.ts
@@ -243,7 +243,7 @@ describe('release > createRelease', () => {
           {
             block_id: 'release-changelog-block',
             text: {
-              text: '•   <http://gitlab.example.com/my-group/my-project/merge_requests/1|feat(great): implement great feature> - <https://my-ticket-management.com/view/SPAR-156|SPAR-156>\n•   <http://gitlab.example.com/my-group/my-project/merge_requests/1|feat(great): implement another great feature> - <https://my-ticket-management.com/view/SPAR-158|SPAR-158>\n',
+              text: '•   <http://gitlab.example.com/my-group/my-project/-/merge_requests/1|feat(great): implement great feature> - <https://my-ticket-management.com/view/SPAR-156|SPAR-156>\n•   <http://gitlab.example.com/my-group/my-project/-/merge_requests/1|feat(great): implement another great feature> - <https://my-ticket-management.com/view/SPAR-158|SPAR-158>\n',
               type: 'mrkdwn',
             },
             type: 'section',
@@ -406,7 +406,7 @@ describe('release > createRelease', () => {
           {
             block_id: 'release-changelog-block',
             text: {
-              text: '•   <http://gitlab.example.com/my-group/my-project/merge_requests/1|feat(great): implement great feature> - <https://my-ticket-management.com/view/SPAR-156|SPAR-156>\n•   <http://gitlab.example.com/my-group/my-project/merge_requests/1|feat(great): implement another great feature> - <https://my-ticket-management.com/view/SPAR-158|SPAR-158>\n',
+              text: '•   <http://gitlab.example.com/my-group/my-project/-/merge_requests/1|feat(great): implement great feature> - <https://my-ticket-management.com/view/SPAR-156|SPAR-156>\n•   <http://gitlab.example.com/my-group/my-project/-/merge_requests/1|feat(great): implement another great feature> - <https://my-ticket-management.com/view/SPAR-158|SPAR-158>\n',
               type: 'mrkdwn',
             },
             type: 'section',
@@ -567,7 +567,7 @@ describe('release > createRelease', () => {
     ).toEqual(true);
     expect(releaseCallMock.called).toEqual(true);
     expect(releaseCallMock.calledWith?.[1]).toEqual({
-      body: `{"description":"- [feat(great): implement great feature](http://gitlab.example.com/my-group/my-project/merge_requests/1) - [SPAR-156](https://my-ticket-management.com/view/SPAR-156)\\n- [feat(great): implement another great feature](http://gitlab.example.com/my-group/my-project/merge_requests/1) - [SPAR-158](https://my-ticket-management.com/view/SPAR-158)","tag_name":"${releaseTagName}","ref":"${pipelineFixture.sha}"}`,
+      body: `{"description":"- [feat(great): implement great feature](http://gitlab.example.com/my-group/my-project/-/merge_requests/1) - [SPAR-156](https://my-ticket-management.com/view/SPAR-156)\\n- [feat(great): implement another great feature](http://gitlab.example.com/my-group/my-project/-/merge_requests/1) - [SPAR-158](https://my-ticket-management.com/view/SPAR-158)","tag_name":"${releaseTagName}","ref":"${pipelineFixture.sha}"}`,
       headers: { 'Content-Type': 'application/json' },
       method: 'post',
     });
@@ -607,8 +607,8 @@ describe('release > createRelease', () => {
           text: {
             text: `\
 :homer: New release <${projectFixture.web_url}/-/releases/stable-19700101-0100|${releaseTagName}> for project <${projectFixture.web_url}|${projectFixture.path_with_namespace}>:
-  •   <http://gitlab.example.com/my-group/my-project/merge_requests/1|feat(great): implement great feature> - <https://my-ticket-management.com/view/SPAR-156|SPAR-156>
-  •   <http://gitlab.example.com/my-group/my-project/merge_requests/1|feat(great): implement another great feature> - <https://my-ticket-management.com/view/SPAR-158|SPAR-158>`,
+  •   <http://gitlab.example.com/my-group/my-project/-/merge_requests/1|feat(great): implement great feature> - <https://my-ticket-management.com/view/SPAR-156|SPAR-156>
+  •   <http://gitlab.example.com/my-group/my-project/-/merge_requests/1|feat(great): implement another great feature> - <https://my-ticket-management.com/view/SPAR-158|SPAR-158>`,
             type: 'mrkdwn',
           },
           type: 'section',
@@ -762,7 +762,7 @@ wait for them and start the release automatically (<${pipelineFixture.web_url}|p
     await waitFor(() => {
       expect(releaseCallMock.called).toEqual(true);
       expect(releaseCallMock.calledWith?.[1]).toEqual({
-        body: `{"description":"- [feat(great): implement great feature](http://gitlab.example.com/my-group/my-project/merge_requests/1) - [SPAR-156](https://my-ticket-management.com/view/SPAR-156)\\n- [feat(great): implement another great feature](http://gitlab.example.com/my-group/my-project/merge_requests/1) - [SPAR-158](https://my-ticket-management.com/view/SPAR-158)","tag_name":"${releaseTagName}","ref":"${pipelineFixture.sha}"}`,
+        body: `{"description":"- [feat(great): implement great feature](http://gitlab.example.com/my-group/my-project/-/merge_requests/1) - [SPAR-156](https://my-ticket-management.com/view/SPAR-156)\\n- [feat(great): implement another great feature](http://gitlab.example.com/my-group/my-project/-/merge_requests/1) - [SPAR-158](https://my-ticket-management.com/view/SPAR-158)","tag_name":"${releaseTagName}","ref":"${pipelineFixture.sha}"}`,
         headers: { 'Content-Type': 'application/json' },
         method: 'post',
       });

--- a/__tests__/utils/mockBuildReviewMessageCalls.ts
+++ b/__tests__/utils/mockBuildReviewMessageCalls.ts
@@ -12,7 +12,7 @@ export function mockBuildReviewMessageCalls() {
   const projectPath = url.pathname
     .split('/')
     .filter(Boolean)
-    .slice(0, -2)
+    .slice(0, -3)
     .join('/');
 
   mockGitlabCall(

--- a/src/core/services/gitlab.ts
+++ b/src/core/services/gitlab.ts
@@ -375,7 +375,7 @@ async function searchMergeRequestsByUrl(
   const projectPath = url.pathname
     .split('/')
     .filter(Boolean)
-    .slice(0, -2)
+    .slice(0, -3)
     .join('/');
 
   return Promise.all([


### PR DESCRIPTION
The mergeRequestfixture was incorrect, the URL of a MR is build like this : 

`http://gitlab.example.com/my-group/my-project/-/merge_requests/1` instead of `http://gitlab.example.com/my-group/my-project/merge_requests/1`

I fixed the retrievement of the projectPath to handle the additional `/-/`