### PR TITLE
feat(loading-release): Add a loading modal for the release creation to avoid potential expired trigger_id (3sec timeout from slack)

### DIFF
--- a/src/release/commands/create/createReleaseRequestHandler.ts
+++ b/src/release/commands/create/createReleaseRequestHandler.ts
@@ -5,6 +5,7 @@ import type {
   SlackExpressRequest,
   SlackSlashCommandResponse,
 } from '@/core/typings/SlackSlashCommand';
+import { buildReleaseModalLoadingView } from '@/release/commands/create/viewBuilders/buildReleaseModalLoadingView';
 import { buildReleaseModalView } from './viewBuilders/buildReleaseModalView';
 
 export async function createReleaseRequestHandler(
@@ -15,8 +16,15 @@ export async function createReleaseRequestHandler(
 
   const { channel_id, trigger_id } = req.body as SlackSlashCommandResponse;
 
-  await slackBotWebClient.views.open({
+  const loadingView = await slackBotWebClient.views.open({
     trigger_id,
-    view: await buildReleaseModalView({ channelId: channel_id }),
+    view: await buildReleaseModalLoadingView(),
   });
+
+  if (loadingView.view) {
+    await slackBotWebClient.views.update({
+      view_id: loadingView.view.id,
+      view: await buildReleaseModalView({ channelId: channel_id }),
+    });
+  }
 }

--- a/src/release/commands/create/viewBuilders/buildReleaseModalLoadingView.ts
+++ b/src/release/commands/create/viewBuilders/buildReleaseModalLoadingView.ts
@@ -1,0 +1,26 @@
+import type { View } from '@slack/web-api';
+
+export async function buildReleaseModalLoadingView(): Promise<View> {
+  return {
+    type: 'modal',
+    callback_id: 'release-create-modal',
+    title: {
+      type: 'plain_text',
+      text: 'Release',
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'Start',
+    },
+    notify_on_close: false,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'plain_text',
+          text: ':loader: Loading projects data, please wait...',
+        },
+      },
+    ],
+  };
+}

--- a/src/release/commands/create/viewBuilders/buildReleaseModalLoadingView.ts
+++ b/src/release/commands/create/viewBuilders/buildReleaseModalLoadingView.ts
@@ -18,7 +18,7 @@ export async function buildReleaseModalLoadingView(): Promise<View> {
         type: 'section',
         text: {
           type: 'plain_text',
-          text: ':loader: Loading projects data, please wait...',
+          text: ':loader: Loading project data, please wait…',
         },
       },
     ],


### PR DESCRIPTION
### Problem
When users initiate a release creation, the system currently takes a significant amount of time to generate and display the modal. This creates a poor user experience with no feedback during the wait period.

### Solution
This PR implements a two-step modal approach:

- Immediately display a loading modal (< 3 seconds response time)
- Update the same modal with release information once processing is complete