### PR TITLE
chore: add `not_approved` to the status checked by `homer-mergeable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you want to get an overview of merge requests that are still being reviewed
 If you want to share a merge request in a Slack channel, you can add one of the following label to your merge request:
 
 - `homer-review`: Homer will share the merge request in the channel linked to the Gitlab project.
-- `homer-mergeable`: Homer will share the merge request in the channel linked to the Gitlab project, when it is mergeable.
+- `homer-mergeable`: Homer will share the merge request in the channel linked to the Gitlab project, when it is mergeable or waiting for an approval.
 
 More information about the labels can be found in the [Gitlab documentation](https://docs.gitlab.com/user/project/labels/).
 

--- a/src/review/commands/share/hookHandlers/mergeRequestHookHandler.ts
+++ b/src/review/commands/share/hookHandlers/mergeRequestHookHandler.ts
@@ -56,7 +56,7 @@ export async function mergeRequestHookHandler(
     const isMergeable =
       labels.some(
         (label: { title: string }) => label.title === LABELS.MERGEABLE
-      ) && detailed_merge_status === 'mergeable';
+      ) && ['mergeable', 'not_approved'].includes(detailed_merge_status);
 
     if (hasReviewLabel || isMergeable) {
       await handleNewReview(projectId, iid);


### PR DESCRIPTION
# What

At MM, our merge request require at least 1 or 2 approvals in order to be `mergeable`, so the `homer-mergeable` tag was not really useful.

We decided to also trigger the review message when the merge request has the status `not_approved` which means that it needs the approvals in order to be `mergeable`.