### PR TITLE
fix: don't display the cancel button when the release is completed without the `monitoring` status

### DIFF
--- a/src/release/commands/create/viewBuilders/buildReleaseMessage.ts
+++ b/src/release/commands/create/viewBuilders/buildReleaseMessage.ts
@@ -122,18 +122,10 @@ function buildHeaderBlock(
   projectPathWithNamespace: string,
   releaseStateUpdates: ReleaseStateUpdate[],
 ): KnownBlock {
-  const DEPLOYMENT_STATE_COMPLETED: DeploymentState = 'completed';
-
   const projectDisplayName =
     projectPathWithNamespace.split('/').pop() ?? projectPathWithNamespace;
 
-  const isReleaseCompleted = releaseStateUpdates.some(
-    (update) =>
-      update.deploymentState === DEPLOYMENT_STATE_COMPLETED &&
-      FINAL_RELEASE_ENVIRONMENTS.includes(update.environment),
-  );
-
-  const releaseInfo = isReleaseCompleted
+  const releaseInfo = isReleaseCompleted(releaseStateUpdates)
     ? { status: 'Completed', emoji: '✅' }
     : { status: 'In Progress', emoji: '🚀' };
 
@@ -384,7 +376,11 @@ function buildDeploymentActionBlock(
   releaseStateUpdates: ReleaseStateUpdate[],
 ): KnownBlock | undefined {
   const actionElements: ActionsBlockElement[] = [];
-  if (release.state !== 'monitoring') {
+
+  if (
+    release.state !== 'monitoring' ||
+    !isReleaseCompleted(releaseStateUpdates)
+  ) {
     actionElements.push({
       type: 'button',
       style: 'danger',
@@ -476,4 +472,15 @@ function createChangelogSummary(rawChangelog: string): string {
   }
 
   return slackifyMarkdown(summary);
+}
+
+function isReleaseCompleted(
+  releaseStateUpdates: ReleaseStateUpdate[],
+): boolean {
+  const DEPLOYMENT_STATE_COMPLETED: DeploymentState = 'completed';
+  return releaseStateUpdates.some(
+    (update) =>
+      update.deploymentState === DEPLOYMENT_STATE_COMPLETED &&
+      FINAL_RELEASE_ENVIRONMENTS.includes(update.environment),
+  );
 }


### PR DESCRIPTION
don't display the cancel button when the release is completed without the monitoring status