### PR TITLE
fix: Display the changelog even if the release is complted and removed from the database

### DIFF
--- a/__tests__/release/displayReleaseChangelog.test.ts
+++ b/__tests__/release/displayReleaseChangelog.test.ts
@@ -2,14 +2,20 @@ import request from 'supertest';
 import { app } from '@/app';
 import { HTTP_STATUS_OK } from '@/constants';
 import { createRelease, updateRelease } from '@/core/services/data';
+import { fetchReleaseByTagName } from '@/core/services/gitlab';
 import { slackBotWebClient } from '@/core/services/slack';
 import type { DataRelease } from '@/core/typings/Data';
+import type { GitlabRelease } from '@/core/typings/GitlabRelease';
 import { slackifyChangelog } from '@/release/commands/create/utils/slackifyChangelog';
 import ConfigHelper from '@/release/utils/ConfigHelper';
 import { projectFixture } from '@root/__tests__/__fixtures__/projectFixture';
 import { releaseFixture } from '@root/__tests__/__fixtures__/releaseFixture';
 import { slackUserFixture } from '@root/__tests__/__fixtures__/slackUserFixture';
 import { getSlackHeaders } from '@root/__tests__/utils/getSlackHeaders';
+
+jest.mock('@/core/services/gitlab', () => ({
+  fetchReleaseByTagName: jest.fn(),
+}));
 
 const initialMockRelease: DataRelease = {
   description:
@@ -24,6 +30,11 @@ const initialMockRelease: DataRelease = {
 };
 
 describe('release > display full changelog', () => {
+  beforeEach(() => {
+    (fetchReleaseByTagName as jest.Mock).mockClear();
+    (slackBotWebClient.views.open as jest.Mock).mockClear();
+  });
+
   it('should open a modal when the display changelog button is clicked', async () => {
     // Given
     const releaseConfig = await ConfigHelper.getProjectReleaseConfig(
@@ -69,6 +80,100 @@ describe('release > display full changelog', () => {
       .send(body);
 
     expect(response.status).toEqual(HTTP_STATUS_OK);
+
+    expect(slackBotWebClient.views.open).toHaveBeenCalledTimes(1);
+    expect(slackBotWebClient.views.open).toHaveBeenCalledWith({
+      trigger_id: 'trigger_id',
+      view: {
+        type: 'modal',
+        callback_id: 'release-changelog-modal',
+        title: {
+          type: 'plain_text',
+          text: `Release Changelog`,
+        },
+        submit: {
+          type: 'plain_text',
+          text: 'Ok',
+        },
+        notify_on_close: false,
+        blocks: [
+          {
+            type: 'header',
+            text: {
+              type: 'plain_text',
+              text: `Release ${initialMockRelease.tagName}`,
+            },
+          },
+          {
+            type: 'divider',
+          },
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: '*✨ Changes*',
+            },
+          },
+          {
+            type: 'section',
+            block_id: 'changelog-preview-block',
+            text: {
+              type: 'mrkdwn',
+              text: slackifyChangelog(initialMockRelease.description),
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('should open a modal with GitLab data when release is not in DB', async () => {
+    // Given
+    (fetchReleaseByTagName as jest.Mock).mockResolvedValue({
+      description: initialMockRelease.description,
+      tag_name: initialMockRelease.tagName,
+    } as GitlabRelease);
+    const releaseConfig = await ConfigHelper.getProjectReleaseConfig(
+      initialMockRelease.projectId,
+    );
+
+    // When
+    const body = {
+      payload: JSON.stringify({
+        type: 'block_actions',
+        trigger_id: 'trigger_id',
+        container: { channel_id: releaseConfig.releaseChannelId },
+        user: { id: slackUserFixture.id },
+        actions: [
+          {
+            action_id: 'release-button-full-changelog-action',
+            block_id: '1Cj9B',
+            text: {
+              type: 'plain_text',
+              text: 'View Full Changelog',
+              emoji: true,
+            },
+            value: `release~~${initialMockRelease.projectId}~~${initialMockRelease.tagName}`,
+            style: 'primary',
+            type: 'button',
+            action_ts: '1761587005.541595',
+          },
+        ],
+      }),
+    };
+
+    const response = await request(app)
+      .post('/api/v1/homer/interactive')
+      .set(getSlackHeaders(body))
+      .send(body);
+
+    // Then
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+
+    expect(fetchReleaseByTagName).toHaveBeenCalledWith(
+      initialMockRelease.projectId,
+      initialMockRelease.tagName,
+    );
 
     expect(slackBotWebClient.views.open).toHaveBeenCalledTimes(1);
     expect(slackBotWebClient.views.open).toHaveBeenCalledWith({

--- a/src/release/commands/changelog/viewBuilders/buildReleaseChangelogModalView.ts
+++ b/src/release/commands/changelog/viewBuilders/buildReleaseChangelogModalView.ts
@@ -1,9 +1,9 @@
 import type { View } from '@slack/types';
-import type { DataRelease } from '@/core/typings/Data';
 import { slackifyChangelog } from '@/release/commands/create/utils/slackifyChangelog';
 
 export async function buildReleaseChangelogModalView(
-  release: DataRelease,
+  tagName: string,
+  description: string,
 ): Promise<View> {
   return {
     type: 'modal',
@@ -22,7 +22,7 @@ export async function buildReleaseChangelogModalView(
         type: 'header',
         text: {
           type: 'plain_text',
-          text: `Release ${release.tagName}`,
+          text: `Release ${tagName}`,
         },
       },
       {
@@ -40,8 +40,8 @@ export async function buildReleaseChangelogModalView(
         block_id: 'changelog-preview-block',
         text: {
           type: 'mrkdwn',
-          text: release.description
-            ? slackifyChangelog(release.description)
+          text: description
+            ? slackifyChangelog(description)
             : 'No change has been found.',
         },
       },


### PR DESCRIPTION
When the release is completed, the data is removed from the database

We need to retrieve the release from gitlab in order to display the changelog.