### PR TITLE
fix(project-path): truncate path if exceeds slack char limit (#22)

### DIFF
--- a/__tests__/changelog/buildChangelogModalView.test.ts
+++ b/__tests__/changelog/buildChangelogModalView.test.ts
@@ -1,0 +1,48 @@
+import type { InputBlock, StaticSelect } from '@slack/web-api';
+import { buildChangelogModalView } from '@/changelog/buildChangelogModalView';
+import { generateChangelog } from '@/changelog/utils/generateChangelog';
+import { getProjectsByChannelId } from '@/core/services/data';
+import { fetchProjectById, fetchProjectTags } from '@/core/services/gitlab';
+import { SLACK_OPTION_TEXT_MAX_LENGTH } from '@/core/utils/truncateProjectPath';
+import { projectFixture } from '../__fixtures__/projectFixture';
+
+jest.mock('@/core/services/data', () => ({
+  ...jest.requireActual('@/core/services/data'),
+  getProjectsByChannelId: jest.fn(),
+}));
+
+jest.mock('@/core/services/gitlab', () => ({
+  ...jest.requireActual('@/core/services/gitlab'),
+  fetchProjectById: jest.fn(),
+  fetchProjectTags: jest.fn(),
+}));
+
+jest.mock('@/changelog/utils/generateChangelog', () => ({
+  generateChangelog: jest.fn(),
+}));
+
+describe('buildChangelogModalView', () => {
+  it('truncates long project paths in the project picker option text', async () => {
+    const longPath = `${'group/'.repeat(15)}very-long-project-name`;
+    expect(longPath.length).toBeGreaterThan(SLACK_OPTION_TEXT_MAX_LENGTH);
+
+    (getProjectsByChannelId as jest.Mock).mockResolvedValue([
+      { projectId: projectFixture.id },
+    ]);
+    (fetchProjectById as jest.Mock).mockResolvedValue({
+      ...projectFixture,
+      path_with_namespace: longPath,
+    });
+    (fetchProjectTags as jest.Mock).mockResolvedValue([]);
+    (generateChangelog as jest.Mock).mockResolvedValue('');
+
+    const view = await buildChangelogModalView({ channelId: 'channelId' });
+
+    const projectBlock = view.blocks[0] as InputBlock;
+    const select = projectBlock.element as StaticSelect;
+    const text = select.options?.[0].text.text as string;
+
+    expect(text.length).toBeLessThanOrEqual(SLACK_OPTION_TEXT_MAX_LENGTH);
+    expect(text.endsWith('…/very-long-project-name')).toBe(true);
+  });
+});

--- a/__tests__/core/utils/truncateProjectPath.test.ts
+++ b/__tests__/core/utils/truncateProjectPath.test.ts
@@ -1,0 +1,62 @@
+import {
+  SLACK_OPTION_TEXT_MAX_LENGTH,
+  truncateProjectPath,
+} from '@/core/utils/truncateProjectPath';
+
+describe('truncateProjectPath', () => {
+  it('returns the path unchanged when it is within the limit', () => {
+    const path = 'group/subgroup/project';
+    expect(truncateProjectPath(path)).toBe(path);
+  });
+
+  it('returns the path unchanged when it is exactly at the limit', () => {
+    const path = `${'a'.repeat(64)}/short-leaf`;
+    expect(path.length).toBe(SLACK_OPTION_TEXT_MAX_LENGTH);
+    expect(truncateProjectPath(path)).toBe(path);
+  });
+
+  it('keeps a prefix of the original path and inserts an ellipsis right before the leaf when the path is too long', () => {
+    const longPrefix = `${'a'.repeat(20)}/${'b'.repeat(20)}/${'c'.repeat(20)}/${'d'.repeat(20)}`;
+    const leaf = 'my-leaf';
+    const path = `${longPrefix}/${leaf}`;
+
+    const result = truncateProjectPath(path);
+
+    expect(result.length).toBeLessThanOrEqual(SLACK_OPTION_TEXT_MAX_LENGTH);
+    expect(result).toMatch(/^.+…\/my-leaf$/);
+    expect(result.endsWith(`…/${leaf}`)).toBe(true);
+    expect(path.startsWith(result.replace(/…\/.+$/, ''))).toBe(true);
+  });
+
+  it('truncates the leaf itself with a leading ellipsis when the leaf alone exceeds the budget for "…/leaf"', () => {
+    const leaf = 'x'.repeat(100);
+    const path = `group/${leaf}`;
+
+    const result = truncateProjectPath(path);
+
+    expect(result.length).toBe(SLACK_OPTION_TEXT_MAX_LENGTH);
+    expect(result.startsWith('…')).toBe(true);
+    expect(result.slice(1)).toBe(
+      leaf.slice(-(SLACK_OPTION_TEXT_MAX_LENGTH - 1)),
+    );
+  });
+
+  it('handles a path with no slash by treating it as a leaf', () => {
+    const leaf = 'y'.repeat(100);
+
+    const result = truncateProjectPath(leaf);
+
+    expect(result.length).toBe(SLACK_OPTION_TEXT_MAX_LENGTH);
+    expect(result.startsWith('…')).toBe(true);
+    expect(result.slice(1)).toBe(
+      leaf.slice(-(SLACK_OPTION_TEXT_MAX_LENGTH - 1)),
+    );
+  });
+
+  it('respects a custom max length', () => {
+    const path = `${'a'.repeat(50)}/leaf`;
+    const result = truncateProjectPath(path, 20);
+    expect(result.length).toBeLessThanOrEqual(20);
+    expect(result.endsWith('…/leaf')).toBe(true);
+  });
+});

--- a/__tests__/project/buildAddProjectSelectionEphemeral.test.ts
+++ b/__tests__/project/buildAddProjectSelectionEphemeral.test.ts
@@ -1,0 +1,46 @@
+import type { SectionBlock, StaticSelect } from '@slack/web-api';
+import type { GitlabProject } from '@/core/typings/GitlabProject';
+import { SLACK_OPTION_TEXT_MAX_LENGTH } from '@/core/utils/truncateProjectPath';
+import { buildAddProjectSelectionEphemeral } from '@/project/commands/add/buildAddProjectSelectionEphemeral';
+import { projectFixture } from '../__fixtures__/projectFixture';
+
+describe('buildAddProjectSelectionEphemeral', () => {
+  it('keeps short project paths unchanged in the option text', () => {
+    const result = buildAddProjectSelectionEphemeral({
+      channelId: 'channelId',
+      projects: [projectFixture as GitlabProject],
+      query: 'search',
+      userId: 'userId',
+    });
+
+    const accessory = (result as { blocks: SectionBlock[] }).blocks[0]
+      .accessory as StaticSelect;
+    expect(accessory.options?.[0].text.text).toBe(
+      projectFixture.path_with_namespace,
+    );
+  });
+
+  it('truncates project paths longer than the Slack 75-char option-text limit', () => {
+    const longPath = `${'group/'.repeat(15)}very-long-project-name`;
+    expect(longPath.length).toBeGreaterThan(SLACK_OPTION_TEXT_MAX_LENGTH);
+
+    const longProject: GitlabProject = {
+      ...(projectFixture as GitlabProject),
+      path_with_namespace: longPath,
+    };
+
+    const result = buildAddProjectSelectionEphemeral({
+      channelId: 'channelId',
+      projects: [longProject],
+      query: 'search',
+      userId: 'userId',
+    });
+
+    const accessory = (result as { blocks: SectionBlock[] }).blocks[0]
+      .accessory as StaticSelect;
+    const text = accessory.options?.[0].text.text as string;
+
+    expect(text.length).toBeLessThanOrEqual(SLACK_OPTION_TEXT_MAX_LENGTH);
+    expect(text.endsWith('…/very-long-project-name')).toBe(true);
+  });
+});

--- a/__tests__/project/buildRemoveProjectSelectionEphemeral.test.ts
+++ b/__tests__/project/buildRemoveProjectSelectionEphemeral.test.ts
@@ -1,0 +1,45 @@
+import type { SectionBlock, StaticSelect } from '@slack/web-api';
+import { getProjectsByChannelId } from '@/core/services/data';
+import { fetchProjectById } from '@/core/services/gitlab';
+import { SLACK_OPTION_TEXT_MAX_LENGTH } from '@/core/utils/truncateProjectPath';
+import { buildRemoveProjectSelectionEphemeral } from '@/project/commands/remove/buildRemoveProjectSelectionEphemeral';
+import { projectFixture } from '../__fixtures__/projectFixture';
+
+jest.mock('@/core/services/data', () => ({
+  ...jest.requireActual('@/core/services/data'),
+  getProjectsByChannelId: jest.fn(),
+}));
+
+jest.mock('@/core/services/gitlab', () => ({
+  ...jest.requireActual('@/core/services/gitlab'),
+  fetchProjectById: jest.fn(),
+}));
+
+describe('buildRemoveProjectSelectionEphemeral', () => {
+  it('truncates long project paths in the option text but keeps the full path in the option value', async () => {
+    const longPath = `${'group/'.repeat(15)}very-long-project-name`;
+    expect(longPath.length).toBeGreaterThan(SLACK_OPTION_TEXT_MAX_LENGTH);
+
+    (getProjectsByChannelId as jest.Mock).mockResolvedValue([
+      { projectId: projectFixture.id },
+    ]);
+    (fetchProjectById as jest.Mock).mockResolvedValue({
+      ...projectFixture,
+      path_with_namespace: longPath,
+    });
+
+    const result = await buildRemoveProjectSelectionEphemeral({
+      channelId: 'channelId',
+      userId: 'userId',
+    });
+
+    const accessory = (result as { blocks: SectionBlock[] }).blocks[0]
+      .accessory as StaticSelect;
+    const option = accessory.options?.[0];
+    const text = option?.text.text as string;
+
+    expect(text.length).toBeLessThanOrEqual(SLACK_OPTION_TEXT_MAX_LENGTH);
+    expect(text.endsWith('…/very-long-project-name')).toBe(true);
+    expect(option?.value).toContain(longPath);
+  });
+});

--- a/__tests__/release/buildReleaseSelectionEphemeral.test.ts
+++ b/__tests__/release/buildReleaseSelectionEphemeral.test.ts
@@ -1,0 +1,44 @@
+import type { SectionBlock, StaticSelect } from '@slack/web-api';
+import { fetchProjectById } from '@/core/services/gitlab';
+import type { DataRelease } from '@/core/typings/Data';
+import { SLACK_OPTION_TEXT_MAX_LENGTH } from '@/core/utils/truncateProjectPath';
+import { buildReleaseSelectionEphemeral } from '@/release/viewBuilders/buildReleaseSelectionEphemeral';
+import { projectFixture } from '../__fixtures__/projectFixture';
+
+jest.mock('@/core/services/gitlab', () => ({
+  ...jest.requireActual('@/core/services/gitlab'),
+  fetchProjectById: jest.fn(),
+}));
+
+describe('buildReleaseSelectionEphemeral', () => {
+  it('truncates long project paths in the option-group label', async () => {
+    const longPath = `${'group/'.repeat(15)}very-long-project-name`;
+    expect(longPath.length).toBeGreaterThan(SLACK_OPTION_TEXT_MAX_LENGTH);
+
+    (fetchProjectById as jest.Mock).mockResolvedValue({
+      ...projectFixture,
+      path_with_namespace: longPath,
+    });
+
+    const release = {
+      projectId: projectFixture.id,
+      tagName: 'stable-19700101-0100',
+    } as DataRelease;
+
+    const result = await buildReleaseSelectionEphemeral({
+      action: 'cancel',
+      channelId: 'channelId',
+      releases: [release],
+      userId: 'userId',
+    });
+
+    const accessory = (result as { blocks: SectionBlock[] }).blocks[0]
+      .accessory as StaticSelect;
+    const groupLabelText = accessory.option_groups?.[0].label.text as string;
+
+    expect(groupLabelText.length).toBeLessThanOrEqual(
+      SLACK_OPTION_TEXT_MAX_LENGTH,
+    );
+    expect(groupLabelText.endsWith('…/very-long-project-name')).toBe(true);
+  });
+});

--- a/src/changelog/buildChangelogModalView.ts
+++ b/src/changelog/buildChangelogModalView.ts
@@ -6,6 +6,7 @@ import { logger } from '@/core/services/logger';
 import type { GitlabProjectDetails } from '@/core/typings/GitlabProject';
 import type { SlackOption } from '@/core/typings/SlackOption';
 import { slackifyText } from '@/core/utils/slackifyText';
+import { truncateProjectPath } from '@/core/utils/truncateProjectPath';
 
 interface ChangelogModalData {
   channelId?: string;
@@ -45,7 +46,7 @@ export async function buildChangelogModalView({
       .map((project) => ({
         text: {
           type: 'plain_text',
-          text: project.path_with_namespace,
+          text: truncateProjectPath(project.path_with_namespace),
         },
         value: project.id.toString(),
       })) as SlackOption[];

--- a/src/core/utils/truncateProjectPath.ts
+++ b/src/core/utils/truncateProjectPath.ts
@@ -1,0 +1,20 @@
+export const SLACK_OPTION_TEXT_MAX_LENGTH = 75;
+
+export function truncateProjectPath(
+  path: string,
+  maxLength: number = SLACK_OPTION_TEXT_MAX_LENGTH,
+): string {
+  if (path.length <= maxLength) {
+    return path;
+  }
+
+  const leaf = path.slice(path.lastIndexOf('/') + 1);
+  const ellipsisAndSlash = 2;
+
+  if (leaf.length > maxLength - ellipsisAndSlash - 1) {
+    return `…${leaf.slice(-(maxLength - 1))}`;
+  }
+
+  const prefixBudget = maxLength - ellipsisAndSlash - leaf.length;
+  return `${path.slice(0, prefixBudget)}…/${leaf}`;
+}

--- a/src/project/commands/add/buildAddProjectSelectionEphemeral.ts
+++ b/src/project/commands/add/buildAddProjectSelectionEphemeral.ts
@@ -1,6 +1,7 @@
 import type { ChatPostEphemeralArguments } from '@slack/web-api';
 import type { GitlabProject } from '@/core/typings/GitlabProject';
 import { injectActionsParameters } from '@/core/utils/slackActions';
+import { truncateProjectPath } from '@/core/utils/truncateProjectPath';
 
 interface AddProjectSelectionEphemeralData {
   channelId: string;
@@ -36,17 +37,17 @@ export function buildAddProjectSelectionEphemeral({
           },
           options: projects
             .sort((a, b) =>
-              a.path_with_namespace.localeCompare(b.path_with_namespace)
+              a.path_with_namespace.localeCompare(b.path_with_namespace),
             )
             .map((project) => ({
               text: {
                 type: 'plain_text',
-                text: project.path_with_namespace,
+                text: truncateProjectPath(project.path_with_namespace),
               },
               value: injectActionsParameters(
                 'project',
                 project.id,
-                project.path_with_namespace
+                project.path_with_namespace,
               ),
             })),
         },

--- a/src/project/commands/remove/buildRemoveProjectSelectionEphemeral.ts
+++ b/src/project/commands/remove/buildRemoveProjectSelectionEphemeral.ts
@@ -2,6 +2,7 @@ import type { ChatPostEphemeralArguments } from '@slack/web-api';
 import { getProjectsByChannelId } from '@/core/services/data';
 import { fetchProjectById } from '@/core/services/gitlab';
 import { injectActionsParameters } from '@/core/utils/slackActions';
+import { truncateProjectPath } from '@/core/utils/truncateProjectPath';
 
 interface RemoveProjectSelectionEphemeralData {
   channelId: string;
@@ -13,9 +14,9 @@ export async function buildRemoveProjectSelectionEphemeral({
   userId,
 }: RemoveProjectSelectionEphemeralData): Promise<ChatPostEphemeralArguments> {
   const projects = await Promise.all(
-    (
-      await getProjectsByChannelId(channelId)
-    ).map(({ projectId }) => fetchProjectById(projectId))
+    (await getProjectsByChannelId(channelId)).map(({ projectId }) =>
+      fetchProjectById(projectId),
+    ),
   );
 
   if (projects.length === 0) {
@@ -47,17 +48,17 @@ export async function buildRemoveProjectSelectionEphemeral({
           },
           options: projects
             .sort((a, b) =>
-              a.path_with_namespace.localeCompare(b.path_with_namespace)
+              a.path_with_namespace.localeCompare(b.path_with_namespace),
             )
             .map((project) => ({
               text: {
                 type: 'plain_text',
-                text: project.path_with_namespace,
+                text: truncateProjectPath(project.path_with_namespace),
               },
               value: injectActionsParameters(
                 'project',
                 project.id,
-                project.path_with_namespace
+                project.path_with_namespace,
               ),
             })),
         },

--- a/src/release/commands/create/viewBuilders/buildReleaseModalView.ts
+++ b/src/release/commands/create/viewBuilders/buildReleaseModalView.ts
@@ -10,6 +10,7 @@ import { fetchProjectById, fetchProjectTags } from '@/core/services/gitlab';
 import type { BlockActionView } from '@/core/typings/BlockActionPayload';
 import type { SlackOption } from '@/core/typings/SlackOption';
 import { slackifyText } from '@/core/utils/slackifyText';
+import { truncateProjectPath } from '@/core/utils/truncateProjectPath';
 import getReleaseOptions from '@/release/releaseOptions';
 import ConfigHelper from '../../../utils/ConfigHelper';
 
@@ -37,7 +38,7 @@ export async function buildReleaseModalView({
     projectId = parseInt(
       state.values['release-project-block']?.['release-select-project-action']
         ?.selected_option?.value,
-      10
+      10,
     );
 
     projectOptions = ((blocks[0] as InputBlock).element as StaticSelect)
@@ -49,18 +50,18 @@ export async function buildReleaseModalView({
       await ConfigHelper.getChannelProjectReleaseConfigs(channelId);
     const projects = await Promise.all(
       projectReleaseConfigs.map(async (config) =>
-        fetchProjectById(config.projectId)
-      )
+        fetchProjectById(config.projectId),
+      ),
     );
 
     projectOptions = projects
       .sort((a, b) =>
-        a.path_with_namespace.localeCompare(b.path_with_namespace)
+        a.path_with_namespace.localeCompare(b.path_with_namespace),
       )
       .map((project) => ({
         text: {
           type: 'plain_text',
-          text: project.path_with_namespace,
+          text: truncateProjectPath(project.path_with_namespace),
         },
         value: project.id.toString(),
       })) as SlackOption[];
@@ -68,7 +69,7 @@ export async function buildReleaseModalView({
 
   if (!projectOptions || projectOptions.length === 0) {
     throw new Error(
-      'No releasable Gitlab project has been found on this channel :homer-stressed:'
+      'No releasable Gitlab project has been found on this channel :homer-stressed:',
     );
   }
 
@@ -86,13 +87,13 @@ export async function buildReleaseModalView({
         projectOptions,
         view,
       },
-      getReleaseOptions()
+      getReleaseOptions(),
     );
   }
 
   if (releaseTagManager === undefined) {
     throw new Error(
-      `The Gitlab project ${projectId} should either provide a release tag manager or a custom build modal method.`
+      `The Gitlab project ${projectId} should either provide a release tag manager or a custom build modal method.`,
     );
   }
 
@@ -167,7 +168,7 @@ export async function buildReleaseModalView({
           type: 'plain_text_input',
           action_id: 'release-tag-action',
           initial_value: releaseTagManager.createReleaseTag(
-            previousReleaseTagName
+            previousReleaseTagName,
           ),
         },
         label: {
@@ -238,7 +239,7 @@ export async function buildReleaseModalView({
           text: changelog
             ? slackifyText(
                 changelog,
-                '*⚠️ Changelog truncated due to Slack limitations.*'
+                '*⚠️ Changelog truncated due to Slack limitations.*',
               )
             : 'No change has been found.',
         },

--- a/src/release/viewBuilders/buildReleaseSelectionEphemeral.ts
+++ b/src/release/viewBuilders/buildReleaseSelectionEphemeral.ts
@@ -2,6 +2,7 @@ import type { ChatPostEphemeralArguments } from '@slack/web-api';
 import { fetchProjectById } from '@/core/services/gitlab';
 import type { DataRelease } from '@/core/typings/Data';
 import { injectActionsParameters } from '@/core/utils/slackActions';
+import { truncateProjectPath } from '@/core/utils/truncateProjectPath';
 
 interface ReleaseSelectionEphemeralData {
   action: string;
@@ -21,13 +22,13 @@ export async function buildReleaseSelectionEphemeral({
   await Promise.all(
     releases.map(async (release) => {
       const { path_with_namespace: projectPath } = await fetchProjectById(
-        release.projectId
+        release.projectId,
       );
       if (releaseGroups[projectPath] === undefined) {
         releaseGroups[projectPath] = [];
       }
       releaseGroups[projectPath].push(release);
-    })
+    }),
   );
 
   return {
@@ -55,7 +56,7 @@ export async function buildReleaseSelectionEphemeral({
             .map(([projectPath, projectReleases]) => ({
               label: {
                 type: 'plain_text',
-                text: projectPath,
+                text: truncateProjectPath(projectPath),
               },
               options: projectReleases.map(({ projectId, tagName }) => ({
                 text: {


### PR DESCRIPTION
###  Root cause
Slack rejected the release modal because option text.text exceeds the 75-char limit. Five Slack `static_select` builders fed `path_with_namespace` (or option-group label) straight to Slack with no length guard. Three other builders (release-modal previous-tag, changelog-modal previous-tag, MR selection) were already safe (short tag names or pre-truncated).  