### PR TITLE
Adjust logs pertinence

### DIFF
--- a/__tests__/core/errorManagement.test.ts
+++ b/__tests__/core/errorManagement.test.ts
@@ -1,11 +1,15 @@
+import type { Request, Response } from 'express';
 import request from 'supertest';
 import { app } from '@/app';
 import {
+  EXPIRED_TRIGGER_ID_ERROR_MESSAGE,
+  EXPIRED_TRIGGER_ID_SLACK_ERROR,
   GENERIC_ERROR_MESSAGE,
   HTTP_STATUS_NO_CONTENT,
   HTTP_STATUS_OK,
   PRIVATE_CHANNEL_ERROR_MESSAGE,
 } from '@/constants';
+import { errorMiddleware } from '@/core/middlewares/errorMiddleware';
 import { addProjectToChannel } from '@/core/services/data';
 import { logger } from '@/core/services/logger';
 import { slackBotWebClient } from '@/core/services/slack';
@@ -75,6 +79,64 @@ describe('core > errorManagement', () => {
         channel: channelId,
         user: userId,
         text: GENERIC_ERROR_MESSAGE,
+      });
+    });
+
+    describe('expired_trigger_id', () => {
+      function makeReqRes(): { req: Request; res: Response; next: jest.Mock } {
+        const req = {
+          header: jest.fn().mockReturnValue(undefined),
+          body: {
+            command: '/homer',
+            user_id: 'U1',
+            channel_id: 'C1',
+          },
+        } as unknown as Request;
+        const res = {
+          headersSent: false,
+          send: jest.fn(),
+        } as unknown as Response;
+        const next = jest.fn();
+        return { req, res, next };
+      }
+
+      it('logs a structured warn with command + user context (not error)', async () => {
+        // Given
+        const error = Object.assign(
+          new Error(`An API error occurred: ${EXPIRED_TRIGGER_ID_SLACK_ERROR}`),
+          { data: { ok: false, error: EXPIRED_TRIGGER_ID_SLACK_ERROR } },
+        );
+        const { req, res, next } = makeReqRes();
+
+        // When
+        await errorMiddleware(error, req, res, next);
+
+        // Then
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            err: error,
+            slackError: EXPIRED_TRIGGER_ID_SLACK_ERROR,
+            command: '/homer',
+            userId: 'U1',
+            channelId: 'C1',
+          }),
+          'slack trigger_id expired before views.open',
+        );
+        expect(logger.error).not.toHaveBeenCalled();
+      });
+
+      it('still replies with the friendly retry message when headers are not yet sent', async () => {
+        // Given
+        const error = new Error(
+          `An API error occurred: ${EXPIRED_TRIGGER_ID_SLACK_ERROR}`,
+        );
+        const { req, res, next } = makeReqRes();
+
+        // When
+        await errorMiddleware(error, req, res, next);
+
+        // Then
+        expect(res.send).toHaveBeenCalledWith(EXPIRED_TRIGGER_ID_ERROR_MESSAGE);
       });
     });
 

--- a/__tests__/core/services/fetchSlackUserFromEmails.test.ts
+++ b/__tests__/core/services/fetchSlackUserFromEmails.test.ts
@@ -1,0 +1,123 @@
+import { logger } from '@/core/services/logger';
+import {
+  fetchSlackUserFromEmails,
+  slackBotWebClient,
+} from '@/core/services/slack';
+import { slackUserFixture } from '../../__fixtures__/slackUserFixture';
+
+function usersNotFoundError(): Error {
+  return Object.assign(new Error('An API error occurred: users_not_found'), {
+    code: 'slack_webapi_platform_error',
+    data: { ok: false, error: 'users_not_found' },
+  });
+}
+
+function rateLimitedError(): Error {
+  return Object.assign(new Error('A rate limit was exceeded'), {
+    code: 'slack_webapi_rate_limited_error',
+    data: { ok: false, error: 'ratelimited' },
+  });
+}
+
+describe('fetchSlackUserFromEmails', () => {
+  const lookupByEmail = slackBotWebClient.users.lookupByEmail as jest.Mock;
+
+  it('returns the user when the first email matches and logs nothing', async () => {
+    lookupByEmail.mockResolvedValueOnce({ user: slackUserFixture });
+
+    const result = await fetchSlackUserFromEmails(['first@example.com']);
+
+    expect(result).toEqual(slackUserFixture);
+    expect(lookupByEmail).toHaveBeenCalledTimes(1);
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the next email when the first returns users_not_found', async () => {
+    lookupByEmail
+      .mockRejectedValueOnce(usersNotFoundError())
+      .mockResolvedValueOnce({ user: slackUserFixture });
+
+    const result = await fetchSlackUserFromEmails([
+      'first@a.com',
+      'second@b.com',
+    ]);
+
+    expect(result).toEqual(slackUserFixture);
+    expect(lookupByEmail).toHaveBeenCalledTimes(2);
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs at info (not error) when every email returns users_not_found', async () => {
+    lookupByEmail
+      .mockRejectedValueOnce(usersNotFoundError())
+      .mockRejectedValueOnce(usersNotFoundError());
+
+    const result = await fetchSlackUserFromEmails(['gone@a.com', 'gone@b.com']);
+
+    expect(result).toBeUndefined();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emails: ['gone@a.com', 'gone@b.com'],
+        slackError: 'users_not_found',
+      }),
+      'no slack user found for emails',
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs at warn when a transient Slack error is encountered', async () => {
+    lookupByEmail.mockRejectedValueOnce(rateLimitedError());
+
+    const result = await fetchSlackUserFromEmails(['user@a.com']);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          data: expect.objectContaining({ error: 'ratelimited' }),
+        }),
+        emails: ['user@a.com'],
+      }),
+      'slack user lookup failed',
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs at warn when at least one lookup throws a transient error, even if another returns users_not_found', async () => {
+    lookupByEmail
+      .mockRejectedValueOnce(usersNotFoundError())
+      .mockRejectedValueOnce(rateLimitedError());
+
+    const result = await fetchSlackUserFromEmails([
+      'gone@a.com',
+      'flaky@b.com',
+    ]);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          data: expect.objectContaining({ error: 'ratelimited' }),
+        }),
+        emails: ['gone@a.com', 'flaky@b.com'],
+      }),
+      'slack user lookup failed',
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined without logging on an empty input', async () => {
+    const result = await fetchSlackUserFromEmails([]);
+
+    expect(result).toBeUndefined();
+    expect(lookupByEmail).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/review/archivedChannelHooks.test.ts
+++ b/__tests__/review/archivedChannelHooks.test.ts
@@ -1,0 +1,205 @@
+import request from 'supertest';
+import { app } from '@/app';
+import { HTTP_STATUS_OK } from '@/constants';
+import { addReviewToChannel } from '@/core/services/data';
+import { logger } from '@/core/services/logger';
+import { slackBotWebClient } from '@/core/services/slack';
+import { mergeRequestHookFixture } from '../__fixtures__/hooks/mergeRequestHookFixture';
+import { pushHookFixture } from '../__fixtures__/hooks/pushHookFixture';
+import { mergeRequestFixture } from '../__fixtures__/mergeRequestFixture';
+import { mergeRequestNoteHookFixture } from '../__fixtures__/mergeRequestNoteBody';
+import { userDetailsFixture } from '../__fixtures__/userDetailsFixture';
+import { getGitlabHeaders } from '../utils/getGitlabHeaders';
+import { mockBuildReviewMessageCalls } from '../utils/mockBuildReviewMessageCalls';
+import { mockGitlabCall } from '../utils/mockGitlabCall';
+import { waitFor } from '../utils/waitFor';
+
+function archivedChannelError(): Error {
+  return Object.assign(new Error('An API error occurred: is_archived'), {
+    code: 'slack_webapi_platform_error',
+    data: { ok: false, error: 'is_archived' },
+  });
+}
+
+describe('archived-channel handling', () => {
+  beforeEach(() => {
+    (slackBotWebClient.users.lookupByEmail as jest.Mock).mockImplementation(
+      ({ email }: { email: string }) => {
+        const name = email.split('@')[0];
+        return Promise.resolve({
+          user: {
+            name,
+            profile: { image_24: 'image_24', image_72: 'image_72' },
+            real_name: `${name}.real`,
+          },
+        });
+      },
+    );
+  });
+
+  it('mergeRequestHookHandler: removes the orphan Review row and logs at info when chat.update returns is_archived', async () => {
+    // Given
+    const { object_attributes, project } = mergeRequestHookFixture;
+    const channelId = 'channelId';
+    await addReviewToChannel({
+      channelId,
+      mergeRequestIid: object_attributes.iid,
+      projectId: project.id,
+      ts: 'ts',
+    });
+    mockBuildReviewMessageCalls();
+    (slackBotWebClient.chat.update as jest.Mock).mockRejectedValueOnce(
+      archivedChannelError(),
+    );
+
+    // When
+    const response = await request(app)
+      .post('/api/v1/homer/gitlab')
+      .set(getGitlabHeaders())
+      .send({
+        ...mergeRequestHookFixture,
+        object_attributes: { ...object_attributes, action: 'approved' },
+      });
+
+    // Then
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+    const { hasModelEntry } = (await import('sequelize')) as any;
+    await waitFor(async () => {
+      expect(
+        await hasModelEntry('Review', {
+          channelId,
+          mergeRequestIid: object_attributes.iid,
+          ts: 'ts',
+        }),
+      ).toBe(false);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hook: 'merge_request',
+          mrIid: object_attributes.iid,
+          projectId: project.id,
+          channelId,
+          reviewTs: 'ts',
+          slackError: 'is_archived',
+        }),
+        'slack channel archived; removing orphan review',
+      );
+    });
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({ hook: 'merge_request' }),
+      'webhook slack work failed',
+    );
+  });
+
+  it('noteHookHandler: removes the orphan Review row and logs at info when chat.update returns is_archived', async () => {
+    // Given
+    const channelId = 'channelId';
+    await addReviewToChannel({
+      channelId,
+      mergeRequestIid: mergeRequestFixture.iid,
+      projectId: mergeRequestFixture.project_id,
+      ts: 'ts',
+    });
+    mockBuildReviewMessageCalls();
+    mockGitlabCall(
+      `/users/${mergeRequestNoteHookFixture.object_attributes.author_id}`,
+      userDetailsFixture,
+    );
+    (slackBotWebClient.chat.update as jest.Mock).mockRejectedValueOnce(
+      archivedChannelError(),
+    );
+    jest.useFakeTimers();
+
+    // When
+    const response = await request(app)
+      .post('/api/v1/homer/gitlab')
+      .set(getGitlabHeaders())
+      .send(mergeRequestNoteHookFixture);
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    // Then
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+    const { hasModelEntry } = (await import('sequelize')) as any;
+    await waitFor(async () => {
+      expect(
+        await hasModelEntry('Review', {
+          channelId,
+          mergeRequestIid: mergeRequestFixture.iid,
+          ts: 'ts',
+        }),
+      ).toBe(false);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hook: 'note',
+          mrIid: mergeRequestFixture.iid,
+          projectId: mergeRequestFixture.project_id,
+          channelId,
+          reviewTs: 'ts',
+          slackError: 'is_archived',
+        }),
+        'slack channel archived; removing orphan review',
+      );
+    });
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({ hook: 'note' }),
+      'webhook slack work failed',
+    );
+  });
+
+  it('pushHookHandler: removes the orphan Review row and logs at info when chat.postMessage returns is_archived', async () => {
+    // Given
+    const branchName = 'master';
+    const channelId = 'channelId';
+    mockGitlabCall(
+      `/projects/${pushHookFixture.project_id}/merge_requests?source_branch=${branchName}`,
+      [mergeRequestFixture],
+    );
+    mockGitlabCall(
+      `/projects/${pushHookFixture.project_id}/merge_requests/${mergeRequestFixture.iid}/commits?per_page=100`,
+      [{ id: pushHookFixture.commits[1].id }],
+    );
+    await addReviewToChannel({
+      channelId,
+      mergeRequestIid: mergeRequestFixture.iid,
+      projectId: mergeRequestFixture.project_id,
+      ts: 'ts',
+    });
+    (slackBotWebClient.chat.postMessage as jest.Mock).mockRejectedValueOnce(
+      archivedChannelError(),
+    );
+
+    // When
+    const response = await request(app)
+      .post('/api/v1/homer/gitlab')
+      .set(getGitlabHeaders())
+      .send(pushHookFixture);
+
+    // Then
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+    const { hasModelEntry } = (await import('sequelize')) as any;
+    await waitFor(async () => {
+      expect(
+        await hasModelEntry('Review', {
+          channelId,
+          mergeRequestIid: mergeRequestFixture.iid,
+          ts: 'ts',
+        }),
+      ).toBe(false);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hook: 'push',
+          mrIid: mergeRequestFixture.iid,
+          projectId: pushHookFixture.project_id,
+          channelId,
+          reviewTs: 'ts',
+          slackError: 'is_archived',
+        }),
+        'slack channel archived; removing orphan review',
+      );
+    });
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({ hook: 'push' }),
+      'webhook slack work failed',
+    );
+  });
+});

--- a/config/jest/setupAfterEnv.ts
+++ b/config/jest/setupAfterEnv.ts
@@ -43,6 +43,7 @@ jest.mock('@/core/services/logger', () => ({
   logger: {
     debug: jest.fn(),
     info: jest.fn(),
+    warn: jest.fn(),
     error: jest.fn(),
   },
 }));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import type { GitlabMergeRequestState } from '@/core/typings/GitlabMergeRequest';
 
 export const CHANNEL_NOT_FOUND_SLACK_ERROR = 'channel_not_found';
+export const IS_ARCHIVED_SLACK_ERROR = 'is_archived';
 export const EXPIRED_TRIGGER_ID_ERROR_MESSAGE =
   'D’oh! It looks like I took too much time to respond for Slack, could you retry your command? :homer-donut:';
 export const EXPIRED_TRIGGER_ID_SLACK_ERROR = 'expired_trigger_id';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,6 @@
 import type { GitlabMergeRequestState } from '@/core/typings/GitlabMergeRequest';
 
 export const CHANNEL_NOT_FOUND_SLACK_ERROR = 'channel_not_found';
-export const IS_ARCHIVED_SLACK_ERROR = 'is_archived';
 export const EXPIRED_TRIGGER_ID_ERROR_MESSAGE =
   'D’oh! It looks like I took too much time to respond for Slack, could you retry your command? :homer-donut:';
 export const EXPIRED_TRIGGER_ID_SLACK_ERROR = 'expired_trigger_id';
@@ -10,6 +9,7 @@ export const GENERIC_ERROR_MESSAGE =
 export const HOMER_GIT_URL = `https://github.com/ManoManoTech/homer/`;
 export const HTTP_STATUS_NO_CONTENT = 204;
 export const HTTP_STATUS_OK = 200;
+export const IS_ARCHIVED_SLACK_ERROR = 'is_archived';
 export const MERGE_REQUEST_CLOSE_STATES: GitlabMergeRequestState[] = [
   'closed',
   'merged',

--- a/src/core/middlewares/errorMiddleware.ts
+++ b/src/core/middlewares/errorMiddleware.ts
@@ -39,6 +39,20 @@ export async function errorMiddleware(
       { err: error, contentLength: req.header('content-length') },
       'request body exceeded size limit',
     );
+  } else if (isExpiredTriggeredIdError) {
+    // The user already gets EXPIRED_TRIGGER_ID_ERROR_MESSAGE as a retry
+    // prompt. This is an expected operational state (cold start, slow DB)
+    // rather than a system failure — log at warn with structured context.
+    logger.warn(
+      {
+        err: error,
+        slackError: EXPIRED_TRIGGER_ID_SLACK_ERROR,
+        command: req.body?.command,
+        userId: req.body?.user_id,
+        channelId: req.body?.channel_id,
+      },
+      'slack trigger_id expired before views.open',
+    );
   } else {
     logger.error(error);
   }

--- a/src/core/services/slack.ts
+++ b/src/core/services/slack.ts
@@ -24,6 +24,15 @@ export async function deleteEphemeralMessage(
   });
 }
 
+/**
+ * True when `err` is a `@slack/web-api` platform error whose Slack-side error
+ * code matches `code` (e.g. 'is_archived', 'channel_not_found'). The shape
+ * comes from `WebAPIPlatformError.data.error`.
+ */
+export function isSlackErrorCode(err: unknown, code: string): boolean {
+  return (err as { data?: { error?: string } } | null)?.data?.error === code;
+}
+
 // See https://api.slack.com/reference/surfaces/formatting#escaping
 export function escapeText(input: string): string {
   return input

--- a/src/core/services/slack.ts
+++ b/src/core/services/slack.ts
@@ -58,38 +58,48 @@ export async function getPermalink(
   return permalink;
 }
 
-export async function fetchSlackUserFromEmail(
-  email: string,
-): Promise<SlackUser | undefined> {
-  try {
-    const response = await slackBotWebClient.users.lookupByEmail({ email });
-    return response.user as SlackUser;
-  } catch (error) {
-    logger.error(error, `Failed to to fetch slack user with email ${email}`);
-  }
-}
+const USERS_NOT_FOUND_SLACK_ERROR = 'users_not_found';
 
+/**
+ * Tries each email against `users.lookupByEmail` and returns the first match.
+ *
+ * Logging policy when no user is found:
+ *  - All lookups returned `users_not_found` → `logger.info` (expected
+ *    operational state: GitLab user left the company / is external / has no
+ *    corporate Slack account).
+ *  - At least one lookup threw a transient error (rate-limited, 5xx, …) →
+ *    `logger.warn` with the underlying error, since this may indicate Slack
+ *    health rather than user absence.
+ */
 export async function fetchSlackUserFromEmails(
   emails: string[],
 ): Promise<SlackUser | undefined> {
-  let user: SlackUser | undefined;
+  let transientError: unknown;
 
   for (const email of emails) {
     try {
       const response = await slackBotWebClient.users.lookupByEmail({ email });
-      user = response.user as SlackUser;
-      break;
-    } catch {
-      // Ignore
+      return response.user as SlackUser;
+    } catch (error) {
+      if (!isSlackErrorCode(error, USERS_NOT_FOUND_SLACK_ERROR)) {
+        transientError = error;
+      }
     }
   }
 
-  if (user === undefined) {
-    logger.error(
-      `Failed to to fetch slack user with emails ${emails.join(', ')}`,
+  if (emails.length === 0) {
+    return undefined;
+  }
+
+  if (transientError !== undefined) {
+    logger.warn({ err: transientError, emails }, 'slack user lookup failed');
+  } else {
+    logger.info(
+      { emails, slackError: USERS_NOT_FOUND_SLACK_ERROR },
+      'no slack user found for emails',
     );
   }
-  return user;
+  return undefined;
 }
 
 export async function fetchSlackUserFromGitlabUser({

--- a/src/review/commands/share/hookHandlers/mergeRequestHookHandler.ts
+++ b/src/review/commands/share/hookHandlers/mergeRequestHookHandler.ts
@@ -12,6 +12,7 @@ import {
   fetchSlackUserFromGitlabUsername,
   slackBotWebClient,
 } from '@/core/services/slack';
+import { handleReviewWebhookError } from '../utils/handleReviewWebhookError';
 import { buildReviewMessage } from '../viewBuilders/buildReviewMessage';
 
 const VALID_ACTIONS = [
@@ -81,25 +82,31 @@ export async function mergeRequestHookHandler(
 
   await Promise.all(
     reviews.map(async ({ channelId, ts }) => {
-      const updates = [
-        buildReviewMessage(channelId, projectId, iid, ts).then(
-          slackBotWebClient.chat.update,
-        ),
-        threadMessage &&
-          slackBotWebClient.chat.postMessage({
-            channel: channelId,
-            thread_ts: ts,
-            ...threadMessage,
-          }),
-      ].filter(Boolean);
-      return Promise.all(updates);
+      try {
+        await Promise.all(
+          [
+            buildReviewMessage(channelId, projectId, iid, ts).then(
+              slackBotWebClient.chat.update,
+            ),
+            threadMessage &&
+              slackBotWebClient.chat.postMessage({
+                channel: channelId,
+                thread_ts: ts,
+                ...threadMessage,
+              }),
+          ].filter(Boolean),
+        );
+      } catch (err) {
+        await handleReviewWebhookError(err, {
+          hook: 'merge_request',
+          mrIid: iid,
+          projectId,
+          channelId,
+          reviewTs: ts,
+        });
+      }
     }),
-  ).catch((err) => {
-    logger.error(
-      { err, hook: 'merge_request', mrIid: iid, projectId },
-      'webhook slack work failed',
-    );
-  });
+  );
 
   if (['close', 'merge'].includes(action)) {
     await removeReviewsByMergeRequestIid(iid);
@@ -120,22 +127,26 @@ async function handleNewReview(projectId: number, iid: number): Promise<void> {
 
   await Promise.all(
     configuredChannels.map(async ({ channelId }) => {
-      const { ts } = await slackBotWebClient.chat.postMessage(
-        await buildReviewMessage(channelId, projectId, iid),
-      );
-      await addReviewToChannel({
-        channelId,
-        mergeRequestIid: iid,
-        projectId,
-        ts: ts as string,
-      });
+      try {
+        const { ts } = await slackBotWebClient.chat.postMessage(
+          await buildReviewMessage(channelId, projectId, iid),
+        );
+        await addReviewToChannel({
+          channelId,
+          mergeRequestIid: iid,
+          projectId,
+          ts: ts as string,
+        });
+      } catch (err) {
+        await handleReviewWebhookError(err, {
+          hook: 'merge_request',
+          mrIid: iid,
+          projectId,
+          channelId,
+        });
+      }
     }),
-  ).catch((err) => {
-    logger.error(
-      { err, hook: 'merge_request', mrIid: iid, projectId },
-      'webhook slack work failed',
-    );
-  });
+  );
 }
 
 function getThreadMessage(

--- a/src/review/commands/share/hookHandlers/noteHookHandler.ts
+++ b/src/review/commands/share/hookHandlers/noteHookHandler.ts
@@ -1,10 +1,10 @@
 import type { Request, Response } from 'express';
 import { HTTP_STATUS_NO_CONTENT, HTTP_STATUS_OK } from '@/constants';
 import { getReviewsByMergeRequestIid } from '@/core/services/data';
-import { logger } from '@/core/services/logger';
 import { slackBotWebClient } from '@/core/services/slack';
 import type { GitlabProjectDetails } from '@/core/typings/GitlabProject';
 import { StateUpdateDebouncer } from '../utils/StateUpdateDebouncer';
+import { handleReviewWebhookError } from '../utils/handleReviewWebhookError';
 import { buildNoteMessage } from '../viewBuilders/buildNoteMessage';
 import { buildReviewMessage } from '../viewBuilders/buildReviewMessage';
 
@@ -44,40 +44,43 @@ export async function noteHookHandler(
   res.sendStatus(HTTP_STATUS_OK);
 
   await Promise.all(
-    reviews
-      .map(({ channelId, ts }) => {
-        const shockAbsorberId = `${channelId}_${ts}_${object_attributes.author_id}`;
+    reviews.map(async ({ channelId, ts }) => {
+      const shockAbsorberId = `${channelId}_${ts}_${object_attributes.author_id}`;
 
-        if (!shockAbsorbers.has(shockAbsorberId)) {
-          shockAbsorbers.set(
-            shockAbsorberId,
-            new StateUpdateDebouncer([], (state) => {
-              shockAbsorbers.delete(shockAbsorberId);
-              return buildNoteMessage(channelId, ts, state).then(
-                slackBotWebClient.chat.postMessage,
-              );
-            }),
-          );
-        }
+      if (!shockAbsorbers.has(shockAbsorberId)) {
+        shockAbsorbers.set(
+          shockAbsorberId,
+          new StateUpdateDebouncer([], (state) => {
+            shockAbsorbers.delete(shockAbsorberId);
+            return buildNoteMessage(channelId, ts, state).then(
+              slackBotWebClient.chat.postMessage,
+            );
+          }),
+        );
+      }
 
-        const shockAbsorber: StateUpdateDebouncer<
-          { author_id: number; note: string; url: string }[]
-        > = shockAbsorbers.get(shockAbsorberId)!;
+      const shockAbsorber: StateUpdateDebouncer<
+        { author_id: number; note: string; url: string }[]
+      > = shockAbsorbers.get(shockAbsorberId)!;
 
-        shockAbsorber.state = [...shockAbsorber.state, object_attributes];
+      shockAbsorber.state = [...shockAbsorber.state, object_attributes];
 
-        return [
+      try {
+        await Promise.all([
           buildReviewMessage(channelId, project.id, iid, ts).then(
             slackBotWebClient.chat.update,
           ),
           shockAbsorber.promise,
-        ];
-      })
-      .flat(),
-  ).catch((err) => {
-    logger.error(
-      { err, hook: 'note', mrIid: iid, projectId: project.id },
-      'webhook slack work failed',
-    );
-  });
+        ]);
+      } catch (err) {
+        await handleReviewWebhookError(err, {
+          hook: 'note',
+          mrIid: iid,
+          projectId: project.id,
+          channelId,
+          reviewTs: ts,
+        });
+      }
+    }),
+  );
 }

--- a/src/review/commands/share/hookHandlers/pushHookHandler.ts
+++ b/src/review/commands/share/hookHandlers/pushHookHandler.ts
@@ -7,7 +7,7 @@ import {
   fetchMergeRequestsByBranchName,
 } from '@/core/services/gitlab';
 import {
-  fetchSlackUserFromEmail,
+  fetchSlackUserFromEmails,
   slackBotWebClient,
 } from '@/core/services/slack';
 import type { DataReview } from '@/core/typings/Data';
@@ -85,9 +85,9 @@ export async function pushHookHandler(
             await Promise.all<KnownBlock[]>(
               newMergeRequestCommits.map(
                 async (commit: GitlabPushedCommit): Promise<KnownBlock[]> => {
-                  const author = await fetchSlackUserFromEmail(
+                  const author = await fetchSlackUserFromEmails([
                     commit.author.email,
-                  );
+                  ]);
                   return [
                     {
                       type: 'section',

--- a/src/review/commands/share/hookHandlers/pushHookHandler.ts
+++ b/src/review/commands/share/hookHandlers/pushHookHandler.ts
@@ -6,13 +6,13 @@ import {
   fetchMergeRequestCommits,
   fetchMergeRequestsByBranchName,
 } from '@/core/services/gitlab';
-import { logger } from '@/core/services/logger';
 import {
   fetchSlackUserFromEmail,
   slackBotWebClient,
 } from '@/core/services/slack';
 import type { DataReview } from '@/core/typings/Data';
 import type { GitlabPushedCommit } from '@/core/typings/GitlabPushedCommit';
+import { handleReviewWebhookError } from '../utils/handleReviewWebhookError';
 
 export async function pushHookHandler(
   req: Request,
@@ -127,12 +127,15 @@ export async function pushHookHandler(
               ),
             )
           ).flat(),
-        }))().catch((err) => {
-        logger.error(
-          { err, hook: 'push', mrIid: mergeRequestIid, projectId: project_id },
-          'webhook slack work failed',
-        );
-      }),
+        }))().catch((err) =>
+        handleReviewWebhookError(err, {
+          hook: 'push',
+          mrIid: mergeRequestIid,
+          projectId: project_id,
+          channelId,
+          reviewTs: ts,
+        }),
+      ),
     ),
   );
 }

--- a/src/review/commands/share/utils/handleReviewWebhookError.ts
+++ b/src/review/commands/share/utils/handleReviewWebhookError.ts
@@ -1,0 +1,39 @@
+import { IS_ARCHIVED_SLACK_ERROR } from '@/constants';
+import { removeReview } from '@/core/services/data';
+import { logger } from '@/core/services/logger';
+import { isSlackErrorCode } from '@/core/services/slack';
+
+interface ReviewWebhookErrorContext {
+  hook: 'merge_request' | 'note' | 'push';
+  mrIid: number;
+  projectId: number;
+  channelId: string;
+  reviewTs?: string;
+}
+
+/**
+ * Policy applied when a Slack call fails inside one of the review-flow webhook
+ * handlers (note / merge_request / push).
+ *
+ * - `is_archived` on a row we own: the channel is permanently dead, so drop
+ *   the orphan Review row and log at info (operational state, not failure).
+ *   The Project↔channel link is left intact so the integration recovers if
+ *   the channel is later unarchived.
+ * - anything else: surface via the structured error log introduced for
+ *   webhook drop visibility.
+ */
+export async function handleReviewWebhookError(
+  err: unknown,
+  ctx: ReviewWebhookErrorContext,
+): Promise<void> {
+  if (isSlackErrorCode(err, IS_ARCHIVED_SLACK_ERROR) && ctx.reviewTs) {
+    logger.info(
+      { ...ctx, slackError: IS_ARCHIVED_SLACK_ERROR },
+      'slack channel archived; removing orphan review',
+    );
+    await removeReview(ctx.reviewTs);
+    return;
+  }
+
+  logger.error({ err, ...ctx }, 'webhook slack work failed');
+}


### PR DESCRIPTION
### Drop orphan Review rows when Slack channel is archived
  When a Slack channel is archived, every chat.update / chat.postMessage from a review-flow webhook returns is_archived and the Review row keeps pointing at the dead channel — re-triggering the failure (and commit 1's webhook slack work failed log) on every subsequent MR update, note or push. Channels do get archived as a routine cleanup; treat it as an expected operational state rather than a hard error.
### Demote expired_trigger_id to structured warn
`errorMiddleware` already replies with `EXPIRED_TRIGGER_ID_ERROR_MESSAGE` when Slack rejects a `views.open` with `expired_trigger_id`, but the underlying error was still logged through `logger.error(error)` as a bare stack trace.
### Demote users_not_found to info and unify email lookup
"Failed to to fetch slack user with emails" was noisy in the logs: it covered the perfectly normal case of a GitLab user who has left the company (or is external, or has no corporate Slack account) and emitted it at error level with no structured context.
