### PR TITLE
fix(push-hook): retry MR commits fetch to handle GitLab async race condition

### DIFF
--- a/__tests__/review/pushHook.test.ts
+++ b/__tests__/review/pushHook.test.ts
@@ -174,7 +174,7 @@ describe('review > pushHook', () => {
     );
     mockGitlabCall(
       `/projects/${pushHookFixture.project_id}/merge_requests/${mergeRequestFixture.iid}/commits?per_page=100`,
-      [],
+      [{ id: pushHookFixture.commits[0].id }],
     );
 
     // When

--- a/__tests__/review/waitForMergeRequestCommits.test.ts
+++ b/__tests__/review/waitForMergeRequestCommits.test.ts
@@ -1,0 +1,83 @@
+import { fetchMergeRequestCommits } from '@/core/services/gitlab';
+import { logger } from '@/core/services/logger';
+import { waitForMergeRequestCommits } from '@/review/commands/share/utils/waitForMergeRequestCommits';
+
+jest.mock('@/core/services/gitlab');
+
+const mockFetch = fetchMergeRequestCommits as jest.Mock;
+
+describe('review > waitForMergeRequestCommits', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns immediately when a pushed commit is found on the first fetch', async () => {
+    const commits = [{ id: 'abc' }, { id: 'def' }];
+    mockFetch.mockResolvedValue(commits);
+
+    const result = await waitForMergeRequestCommits(1, 42, new Set(['abc']));
+
+    expect(result).toBe(commits);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries until a pushed commit appears in the MR', async () => {
+    const matchingCommits = [{ id: 'abc' }];
+    mockFetch
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue(matchingCommits);
+
+    const promise = waitForMergeRequestCommits(1, 42, new Set(['abc']));
+    await jest.advanceTimersByTimeAsync(2000);
+
+    expect(await promise).toBe(matchingCommits);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries when GitLab returns a non-2xx response', async () => {
+    const matchingCommits = [{ id: 'abc' }];
+    mockFetch
+      .mockResolvedValueOnce({ message: '503 Service Unavailable' })
+      .mockResolvedValue(matchingCommits);
+
+    const promise = waitForMergeRequestCommits(1, 42, new Set(['abc']));
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(await promise).toBe(matchingCommits);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries after a network error', async () => {
+    const matchingCommits = [{ id: 'abc' }];
+    mockFetch
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue(matchingCommits);
+
+    const promise = waitForMergeRequestCommits(1, 42, new Set(['abc']));
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(await promise).toBe(matchingCommits);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch commits for MR !42'),
+    );
+  });
+
+  it('returns last known commits after timeout and logs a warning', async () => {
+    mockFetch.mockResolvedValue([]);
+
+    const promise = waitForMergeRequestCommits(1, 42, new Set(['abc']));
+    await jest.advanceTimersByTimeAsync(6000);
+
+    expect(await promise).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Pushed commits not found in MR !42 of project 1 after 5000ms',
+    );
+  });
+});

--- a/src/review/commands/share/hookHandlers/pushHookHandler.ts
+++ b/src/review/commands/share/hookHandlers/pushHookHandler.ts
@@ -2,10 +2,7 @@ import type { KnownBlock } from '@slack/types';
 import type { Request, Response } from 'express';
 import { HTTP_STATUS_NO_CONTENT, HTTP_STATUS_OK } from '@/constants';
 import { getReviewsByMergeRequestIid } from '@/core/services/data';
-import {
-  fetchMergeRequestCommits,
-  fetchMergeRequestsByBranchName,
-} from '@/core/services/gitlab';
+import { fetchMergeRequestsByBranchName } from '@/core/services/gitlab';
 import {
   fetchSlackUserFromEmails,
   slackBotWebClient,
@@ -13,6 +10,7 @@ import {
 import type { DataReview } from '@/core/typings/Data';
 import type { GitlabPushedCommit } from '@/core/typings/GitlabPushedCommit';
 import { handleReviewWebhookError } from '../utils/handleReviewWebhookError';
+import { waitForMergeRequestCommits } from '../utils/waitForMergeRequestCommits';
 
 export async function pushHookHandler(
   req: Request,
@@ -37,11 +35,14 @@ export async function pushHookHandler(
       ({ merge_status }) => merge_status !== 'merged',
     ) || [];
 
+  const pushedCommitIds = new Set(commits.map(({ id }) => id));
+
   const mergeRequestsReviews = await Promise.all(
     mergeRequests.map(async (mergeRequest) => {
-      const mergeRequestCommits = await fetchMergeRequestCommits(
+      const mergeRequestCommits = await waitForMergeRequestCommits(
         project_id,
         mergeRequest.iid,
+        pushedCommitIds,
       );
 
       // Removes the rebase commits

--- a/src/review/commands/share/utils/waitForMergeRequestCommits.ts
+++ b/src/review/commands/share/utils/waitForMergeRequestCommits.ts
@@ -1,0 +1,47 @@
+import { fetchMergeRequestCommits } from '@/core/services/gitlab';
+import { logger } from '@/core/services/logger';
+import type { GitlabCommit } from '@/core/typings/GitlabCommit';
+
+const TIMEOUT_MS = 5000;
+const RETRY_DELAY_MS = 1000;
+
+export async function waitForMergeRequestCommits(
+  projectId: number,
+  mergeRequestIid: number,
+  pushedCommitIds: Set<string>,
+): Promise<GitlabCommit[]> {
+  let timeoutReached = false;
+  let lastCommits: GitlabCommit[] = [];
+
+  const timeout = setTimeout(() => {
+    logger.warn(
+      `Pushed commits not found in MR !${mergeRequestIid} of project ${projectId} after ${TIMEOUT_MS}ms`,
+    );
+    timeoutReached = true;
+  }, TIMEOUT_MS);
+
+  while (!timeoutReached) {
+    try {
+      const commits = await fetchMergeRequestCommits(
+        projectId,
+        mergeRequestIid,
+      );
+      if (Array.isArray(commits)) {
+        lastCommits = commits;
+        if (lastCommits.some(({ id }) => pushedCommitIds.has(id))) {
+          clearTimeout(timeout);
+          return lastCommits;
+        }
+      }
+    } catch (error) {
+      logger.warn(
+        `Failed to fetch commits for MR !${mergeRequestIid} of project ${projectId}: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, RETRY_DELAY_MS);
+    });
+  }
+
+  return lastCommits;
+}


### PR DESCRIPTION
## Problem

When Homer receives a push hook, it filters the pushed commits by cross-referencing the GitLab MR commits API — this removes rebase noise by keeping only commits that actually belong to the MR.

The issue: GitLab updates MR content **asynchronously**. Right after a push, the just-pushed commit is sometimes absent from the MR commits API response at the time Homer fetches it. The intersection is empty, the handler silently returns 204, and no Slack notification is sent. No error is logged, making it invisible.

## Fix

Introduce `waitForMergeRequestCommits`, a utility that polls the MR commits endpoint until at least one pushed commit appears, then returns. It follows the same pattern as the existing `waitForReleasePipeline`.

- Retries every 1s up to a 5s timeout
- Transient fetch errors (e.g. GitLab 5xx) are caught and retried rather than aborting
- Falls back to the last known result on timeout, preserving the existing silent-204 behaviour as a last resort
- Logs a warning on timeout so the failure becomes visible

## Trade-offs

- The webhook response is now delayed by up to ~5s on the stuck path. GitLab's default webhook timeout is 10s so this should be safe, but worth monitoring.
- A cleaner long-term design would be to **ack the webhook immediately (200) and process asynchronously**, which would remove the timeout concern entirely and allow a more generous retry window. Left as a future improvement.

## Changes

- `src/review/commands/share/utils/waitForMergeRequestCommits.ts` — new polling utility
- `src/review/commands/share/hookHandlers/pushHookHandler.ts` — use the new utility
- `__tests__/review/waitForMergeRequestCommits.test.ts` — unit tests covering: immediate hit, retry-until-found, error retry, timeout
- `__tests__/review/pushHook.test.ts` — one-line update: the "no related review" test now correctly gets its 204 from no review in DB (the retry logic is owned by the unit tests above)