### PR TITLE
fix(release): refresh release numbers when switching projects

### DIFF
--- a/PLUGIN_RELEASE.md
+++ b/PLUGIN_RELEASE.md
@@ -8,13 +8,11 @@ You can create a project containing a `plugins/release` directory which will con
 ## Steps to Add a Custom Release Manager
 
 1. **Create a New Release Manager**
-
    - Navigate to the `plugins/release` directory in your Homer project.
    - Create `myOwnReleaseManager.js` and implement the logic(for now the types are not available as a standalone package but you can have the interface [here](./src/release/typings/ReleaseManager.ts)).
    - You have an implementation example with [defaultReleaseManager](./plugins/release/defaultReleaseManager.ts)
 
 2. **Register the Plugin**
-
    - If you have a project which needs the custom release manager, declare the project in the configuration [file](./config/homer/projects.json)
    - Add an entry for your project (the name of the release manager must correspond to its file name).
      ```json
@@ -30,6 +28,28 @@ You can create a project containing a `plugins/release` directory which will con
 
 3. **Deploy**
    - Build the plugins and config with Homer project before deploying the application.
+
+## Reading the release modal state
+
+Slack preserves the value of an input block across `views.update` calls as long
+as its `block_id` **and** `action_id` stay the same, ignoring the new
+`initial_value` / `initial_option`
+(see [views.update](https://docs.slack.dev/reference/methods/views.update/)).
+Homer therefore rotates the `block_id` of the inputs whose content depends on
+the selected project, so that Slack rebuilds them.
+
+As a consequence, **block ids of the release modal must not be relied on**. The
+stable contract is made of the action ids:
+
+| Action id                            | Element                     |
+| ------------------------------------ | --------------------------- |
+| `release-select-project-action`      | project select              |
+| `release-tag-action`                 | release tag input           |
+| `release-select-previous-tag-action` | previous release tag select |
+
+Use `options.slack.getViewStateValue(view, actionId)` to read the view state,
+and emit those action ids from a custom `buildReleaseModalView` so that the core
+submission handling keeps working.
 
 ## Conclusion
 

--- a/__tests__/changelog/buildChangelogModalView.test.ts
+++ b/__tests__/changelog/buildChangelogModalView.test.ts
@@ -1,10 +1,24 @@
-import type { InputBlock, StaticSelect } from '@slack/web-api';
+import type {
+  InputBlock,
+  PlainTextInput,
+  StaticSelect,
+  View,
+} from '@slack/web-api';
 import { buildChangelogModalView } from '@/changelog/buildChangelogModalView';
 import { generateChangelog } from '@/changelog/utils/generateChangelog';
 import { getProjectsByChannelId } from '@/core/services/data';
 import { fetchProjectById, fetchProjectTags } from '@/core/services/gitlab';
+import type { SlackOption } from '@/core/typings/SlackOption';
 import { SLACK_OPTION_TEXT_MAX_LENGTH } from '@/core/utils/truncateProjectPath';
 import { projectFixture } from '../__fixtures__/projectFixture';
+
+function findBlockByActionId(view: View, actionId: string) {
+  return view.blocks.find(
+    (block) =>
+      ((block as InputBlock).element as StaticSelect | PlainTextInput)
+        ?.action_id === actionId,
+  ) as InputBlock | undefined;
+}
 
 jest.mock('@/core/services/data', () => ({
   ...jest.requireActual('@/core/services/data'),
@@ -44,5 +58,51 @@ describe('buildChangelogModalView', () => {
 
     expect(text.length).toBeLessThanOrEqual(SLACK_OPTION_TEXT_MAX_LENGTH);
     expect(text.endsWith('…/very-long-project-name')).toBe(true);
+  });
+
+  it('should key the block ids on the displayed data, and select the requested tag', async () => {
+    (fetchProjectById as jest.Mock).mockResolvedValue(projectFixture);
+    (fetchProjectTags as jest.Mock).mockResolvedValue([
+      { name: '1.2.3' },
+      { name: '1.2.2' },
+    ]);
+    (generateChangelog as jest.Mock).mockResolvedValue('- A change');
+
+    const view = await buildChangelogModalView({
+      projectId: projectFixture.id,
+      projectOptions: [
+        {
+          text: { type: 'plain_text', text: 'diaspora/diaspora-project-site' },
+          value: `${projectFixture.id}`,
+        },
+      ] as SlackOption[],
+      releaseTagName: '1.2.2',
+    });
+
+    const releaseTagBlock = findBlockByActionId(
+      view,
+      'changelog-select-release-tag-action',
+    );
+    const markdownBlock = findBlockByActionId(
+      view,
+      'changelog-markdown-action',
+    );
+
+    // The ids embed the data the inputs display, so that Slack rebuilds them
+    // instead of preserving the values of the previously selected project.
+    expect(releaseTagBlock?.block_id).toEqual(
+      `changelog-release-tag-block-${projectFixture.id}`,
+    );
+    expect(markdownBlock?.block_id).toEqual(
+      `changelog-markdown-block-${projectFixture.id}-1.2.2`,
+    );
+
+    // And the tag asked for is the selected one, not merely the latest.
+    expect(
+      (releaseTagBlock?.element as StaticSelect).initial_option?.value,
+    ).toEqual('1.2.2');
+    expect((markdownBlock?.element as PlainTextInput).initial_value).toEqual(
+      '- A change',
+    );
   });
 });

--- a/__tests__/core/utils/buildBlockId.test.ts
+++ b/__tests__/core/utils/buildBlockId.test.ts
@@ -1,0 +1,40 @@
+import { buildBlockId } from '@/core/utils/buildBlockId';
+
+/** Slack rejects any `block_id` longer than 255 characters. */
+const MAX_BLOCK_ID_LENGTH = 255;
+
+describe('core > utils > buildBlockId', () => {
+  it('should join the prefix and the parts', () => {
+    expect(
+      buildBlockId('release-tag-block', 1148, 'stable-20200101-1000'),
+    ).toEqual('release-tag-block-1148-stable-20200101-1000');
+  });
+
+  it('should mark the missing parts, so that ids of different arities differ', () => {
+    expect(buildBlockId('release-tag-block', 1148, undefined)).toEqual(
+      'release-tag-block-1148-none',
+    );
+    expect(buildBlockId('release-tag-block', 1148, undefined)).not.toEqual(
+      buildBlockId('release-tag-block', 1148),
+    );
+  });
+
+  it('should replace the characters Slack could choke on', () => {
+    expect(
+      buildBlockId('changelog-markdown-block', 1148, 'v1.2.3+rc 1/2'),
+    ).toEqual('changelog-markdown-block-1148-v1.2.3_rc_1_2');
+  });
+
+  it('should hash the id whether it exceeds the length allowed by Slack', () => {
+    const blockId = buildBlockId('release-tag-block', 'a'.repeat(300));
+
+    expect(blockId.length).toBeLessThanOrEqual(MAX_BLOCK_ID_LENGTH);
+    expect(blockId).toMatch(/^release-tag-block-[0-9a-f]{16}$/);
+  });
+
+  it('should not collide when hashing two different long values', () => {
+    expect(
+      buildBlockId('release-tag-block', `${'a'.repeat(300)}1`),
+    ).not.toEqual(buildBlockId('release-tag-block', `${'a'.repeat(300)}2`));
+  });
+});

--- a/__tests__/core/utils/getViewStateValue.test.ts
+++ b/__tests__/core/utils/getViewStateValue.test.ts
@@ -1,0 +1,36 @@
+import { getViewStateValue } from '@/core/utils/getViewStateValue';
+
+describe('core > utils > getViewStateValue', () => {
+  const view = {
+    state: {
+      values: {
+        'a-rotated-block-id-1148': {
+          'select-project-action': { selected_option: { value: '1148' } },
+        },
+        'another-rotated-block-id-1148-1.2.3': {
+          'tag-action': { type: 'plain_text_input', value: '1.2.4' },
+        },
+      },
+    },
+  };
+
+  it('should find a value whatever the block it belongs to', () => {
+    expect(
+      getViewStateValue(view, 'select-project-action')?.selected_option?.value,
+    ).toEqual('1148');
+    expect(getViewStateValue(view, 'tag-action')?.value).toEqual('1.2.4');
+  });
+
+  it('should return undefined for an unknown action id', () => {
+    expect(getViewStateValue(view, 'unknown-action')).toBeUndefined();
+  });
+
+  it('should return undefined whether the state is missing', () => {
+    expect(getViewStateValue(undefined, 'tag-action')).toBeUndefined();
+    expect(getViewStateValue({}, 'tag-action')).toBeUndefined();
+    expect(getViewStateValue({ state: {} }, 'tag-action')).toBeUndefined();
+    expect(
+      getViewStateValue({ state: { values: {} } }, 'tag-action'),
+    ).toBeUndefined();
+  });
+});

--- a/__tests__/release/createRelease.test.ts
+++ b/__tests__/release/createRelease.test.ts
@@ -201,7 +201,7 @@ describe('release > createRelease', () => {
             },
           },
           {
-            block_id: 'release-tag-block',
+            block_id: 'release-tag-block-1148-stable-20200101-1000',
             element: {
               action_id: 'release-tag-action',
               initial_value: 'stable-19700101-0100',
@@ -214,7 +214,7 @@ describe('release > createRelease', () => {
             type: 'input',
           },
           {
-            block_id: 'release-previous-tag-block',
+            block_id: 'release-previous-tag-block-1148',
             dispatch_action: true,
             element: {
               action_id: 'release-select-previous-tag-action',
@@ -394,7 +394,7 @@ describe('release > createRelease', () => {
             },
           },
           {
-            block_id: 'release-tag-block',
+            block_id: 'release-tag-block-1148-stable-20200101-1000',
             element: {
               action_id: 'release-tag-action',
               initial_value: releaseTagName,
@@ -404,7 +404,7 @@ describe('release > createRelease', () => {
             type: 'input',
           },
           {
-            block_id: 'release-previous-tag-block',
+            block_id: 'release-previous-tag-block-1148',
             dispatch_action: true,
             element: {
               action_id: 'release-select-previous-tag-action',
@@ -479,7 +479,9 @@ describe('release > createRelease', () => {
       .calls[2][0] as ViewsOpenArguments);
 
     const previousTagBlock = [...view.blocks].find(
-      (block) => block.block_id === 'release-previous-tag-block',
+      (block) =>
+        ((block as InputBlock).element as StaticSelect)?.action_id ===
+        'release-select-previous-tag-action',
     ) as InputBlock;
     const previousTagElement = previousTagBlock.element as StaticSelect;
 
@@ -541,7 +543,9 @@ describe('release > createRelease', () => {
 
     // Given
     const releaseTagBlock = [...view.blocks].find(
-      (block) => block.block_id === 'release-tag-block',
+      (block) =>
+        ((block as InputBlock).element as PlainTextInput)?.action_id ===
+        'release-tag-action',
     ) as InputBlock;
     const releaseTagElement = releaseTagBlock.element as PlainTextInput;
 

--- a/__tests__/release/switchReleaseProject.test.ts
+++ b/__tests__/release/switchReleaseProject.test.ts
@@ -1,0 +1,305 @@
+import type {
+  InputBlock,
+  PlainTextInput,
+  StaticSelect,
+  ViewsUpdateArguments,
+} from '@slack/web-api';
+import request from 'supertest';
+import { app } from '@/app';
+import { generateChangelog } from '@/changelog/utils/generateChangelog';
+import { HTTP_STATUS_NO_CONTENT, HTTP_STATUS_OK } from '@/constants';
+import { logger } from '@/core/services/logger';
+import { slackBotWebClient } from '@/core/services/slack';
+import { semanticReleaseTagManager } from '@/release/commands/create/managers/semanticReleaseTagManager';
+import { stableDateReleaseTagManager } from '@/release/commands/create/managers/stableDateReleaseTagManager';
+import type { ProjectReleaseConfig } from '@/release/typings/ProjectReleaseConfig';
+import ConfigHelper from '@/release/utils/ConfigHelper';
+import { projectFixture } from '../__fixtures__/projectFixture';
+import { getSlackHeaders } from '../utils/getSlackHeaders';
+import { mockGitlabCall } from '../utils/mockGitlabCall';
+
+jest.mock('@/changelog/utils/generateChangelog', () => ({
+  generateChangelog: jest.fn(),
+}));
+
+jest.mock('@/release/utils/ConfigHelper', () => ({
+  __esModule: true,
+  default: {
+    hasChannelReleaseConfigs: jest.fn(),
+    getChannelProjectReleaseConfigs: jest.fn(),
+    getProjectReleaseConfig: jest.fn(),
+  },
+}));
+
+const channelId = 'C0XXXXXXXXX';
+
+/** Sorted first: the modal sorts the options by path_with_namespace. */
+const firstProject = projectFixture;
+const secondProject = {
+  ...projectFixture,
+  id: 2222,
+  path_with_namespace: 'zz-group/zz-project',
+};
+
+const firstProjectTags = [...Array(5)].map((_, i) => ({
+  name: `stable-20200101-100${i}`,
+}));
+const secondProjectTags = [{ name: '1.2.3' }, { name: '1.2.2' }];
+
+const firstProjectConfig = {
+  notificationChannelIds: [],
+  projectId: firstProject.id,
+  releaseChannelId: channelId,
+  releaseManager: {},
+  releaseTagManager: stableDateReleaseTagManager,
+} as unknown as ProjectReleaseConfig;
+
+const secondProjectConfig = {
+  notificationChannelIds: [],
+  projectId: secondProject.id,
+  releaseChannelId: channelId,
+  releaseManager: {},
+  releaseTagManager: semanticReleaseTagManager,
+} as unknown as ProjectReleaseConfig;
+
+function getUpdatedView(nthCall: number) {
+  return (
+    (slackBotWebClient.views.update as jest.Mock).mock.calls[nthCall - 1][0] as
+      | ViewsUpdateArguments
+      | undefined
+  )?.view;
+}
+
+function findBlockByActionId(
+  blocks: ViewsUpdateArguments['view']['blocks'],
+  actionId: string,
+) {
+  return [...blocks].find(
+    (block) =>
+      ((block as InputBlock).element as StaticSelect | PlainTextInput)
+        ?.action_id === actionId,
+  ) as InputBlock | undefined;
+}
+
+async function postBlockActions(payload: Record<string, unknown>) {
+  const body = { payload: JSON.stringify(payload) };
+
+  return request(app)
+    .post('/api/v1/homer/interactive')
+    .set(getSlackHeaders(body))
+    .send(body);
+}
+
+describe('release > switchReleaseProject', () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+
+    (ConfigHelper.hasChannelReleaseConfigs as jest.Mock).mockResolvedValue(
+      true,
+    );
+    (
+      ConfigHelper.getChannelProjectReleaseConfigs as jest.Mock
+    ).mockResolvedValue([firstProjectConfig, secondProjectConfig]);
+    (ConfigHelper.getProjectReleaseConfig as jest.Mock).mockImplementation(
+      async (projectId: number) =>
+        projectId === secondProject.id
+          ? secondProjectConfig
+          : firstProjectConfig,
+    );
+    (generateChangelog as jest.Mock).mockResolvedValue('');
+    (slackBotWebClient.views.open as jest.Mock).mockResolvedValue({
+      view: { id: 'viewId' },
+    });
+
+    mockGitlabCall(`/projects/${firstProject.id}`, firstProject);
+    mockGitlabCall(`/projects/${secondProject.id}`, secondProject);
+    mockGitlabCall(
+      `/projects/${firstProject.id}/repository/tags?per_page=100`,
+      firstProjectTags,
+    );
+    mockGitlabCall(
+      `/projects/${secondProject.id}/repository/tags?per_page=100`,
+      secondProjectTags,
+    );
+  });
+
+  /** Opens the modal and returns the view displayed by Homer. */
+  async function openReleaseModal() {
+    const body = {
+      channel_id: channelId,
+      text: 'release',
+      trigger_id: 'triggerId',
+    };
+
+    const response = await request(app)
+      .post('/api/v1/homer/command')
+      .set(getSlackHeaders(body))
+      .send(body);
+
+    expect(response.status).toEqual(HTTP_STATUS_NO_CONTENT);
+
+    return getUpdatedView(1) as ViewsUpdateArguments['view'];
+  }
+
+  it('should display the tags of the first project when opening the modal', async () => {
+    const view = await openReleaseModal();
+
+    const projectBlock = findBlockByActionId(
+      view.blocks,
+      'release-select-project-action',
+    );
+    const releaseTagBlock = findBlockByActionId(
+      view.blocks,
+      'release-tag-action',
+    );
+    const previousTagBlock = findBlockByActionId(
+      view.blocks,
+      'release-select-previous-tag-action',
+    );
+
+    expect(
+      (projectBlock?.element as StaticSelect).initial_option?.value,
+    ).toEqual(`${firstProject.id}`);
+    expect(releaseTagBlock?.block_id).toEqual(
+      'release-tag-block-1148-stable-20200101-1000',
+    );
+    expect((releaseTagBlock?.element as PlainTextInput).initial_value).toEqual(
+      'stable-19700101-0100',
+    );
+    expect(previousTagBlock?.block_id).toEqual(
+      'release-previous-tag-block-1148',
+    );
+  });
+
+  it('should refresh the release numbers when switching project', async () => {
+    const view = await openReleaseModal();
+    const projectBlock = findBlockByActionId(
+      view.blocks,
+      'release-select-project-action',
+    ) as InputBlock;
+    const projectOptions = (projectBlock.element as StaticSelect)
+      .options as StaticSelect['options'];
+
+    // When the second project is selected in the combo box
+    const response = await postBlockActions({
+      actions: [{ action_id: 'release-select-project-action' }],
+      type: 'block_actions',
+      view: {
+        ...view,
+        id: 'viewId',
+        state: {
+          values: {
+            [projectBlock.block_id as string]: {
+              'release-select-project-action': {
+                selected_option: projectOptions?.[1],
+              },
+            },
+            // Carried over from the first project, as Slack does.
+            'release-previous-tag-block-1148': {
+              'release-select-previous-tag-action': {
+                selected_option: { value: 'stable-20200101-1000' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+
+    // Then the rebuilt modal displays the second project's release numbers
+    const updatedView = getUpdatedView(3) as ViewsUpdateArguments['view'];
+    const releaseTagBlock = findBlockByActionId(
+      updatedView.blocks,
+      'release-tag-action',
+    );
+    const previousTagBlock = findBlockByActionId(
+      updatedView.blocks,
+      'release-select-previous-tag-action',
+    );
+
+    expect(
+      (
+        findBlockByActionId(updatedView.blocks, 'release-select-project-action')
+          ?.element as StaticSelect
+      ).initial_option?.value,
+    ).toEqual(`${secondProject.id}`);
+
+    expect((releaseTagBlock?.element as PlainTextInput).initial_value).toEqual(
+      '1.2.4',
+    );
+    expect(
+      (previousTagBlock?.element as StaticSelect).initial_option?.value,
+    ).toEqual('1.2.3');
+    expect(
+      (previousTagBlock?.element as StaticSelect).options?.map(
+        ({ value }) => value,
+      ),
+    ).toEqual(['1.2.3', '1.2.2']);
+
+    // And the block ids rotated, so that Slack rebuilds the inputs instead of
+    // preserving the values of the previously selected project.
+    expect(releaseTagBlock?.block_id).toEqual('release-tag-block-2222-1.2.3');
+    expect(previousTagBlock?.block_id).toEqual(
+      'release-previous-tag-block-2222',
+    );
+    expect(
+      updatedView.blocks.filter(({ block_id }) =>
+        block_id?.includes(`${firstProject.id}`),
+      ),
+    ).toEqual([]);
+  });
+
+  it('should fall back to the latest tag whether the selected previous tag does not exist', async () => {
+    const view = await openReleaseModal();
+    const projectBlock = findBlockByActionId(
+      view.blocks,
+      'release-select-project-action',
+    ) as InputBlock;
+    const projectOptions = (projectBlock.element as StaticSelect)
+      .options as StaticSelect['options'];
+
+    // When the previous release tag of another project is kept in the state
+    const response = await postBlockActions({
+      actions: [{ action_id: 'release-select-previous-tag-action' }],
+      type: 'block_actions',
+      view: {
+        ...view,
+        id: 'viewId',
+        state: {
+          values: {
+            [projectBlock.block_id as string]: {
+              'release-select-project-action': {
+                selected_option: projectOptions?.[1],
+              },
+            },
+            'release-previous-tag-block-1148': {
+              'release-select-previous-tag-action': {
+                selected_option: { value: 'stable-20200101-1000' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+
+    // Then the modal is rebuilt instead of being stuck on its loader
+    const updatedView = getUpdatedView(3) as ViewsUpdateArguments['view'];
+    const previousTagBlock = findBlockByActionId(
+      updatedView.blocks,
+      'release-select-previous-tag-action',
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      new Error(
+        `Previous release tag stable-20200101-1000 not found in project ${secondProject.id}`,
+      ),
+    );
+    expect(
+      (previousTagBlock?.element as StaticSelect).initial_option?.value,
+    ).toEqual('1.2.3');
+  });
+});

--- a/__tests__/release/switchReleaseProject.test.ts
+++ b/__tests__/release/switchReleaseProject.test.ts
@@ -302,4 +302,85 @@ describe('release > switchReleaseProject', () => {
       (previousTagBlock?.element as StaticSelect).initial_option?.value,
     ).toEqual('1.2.3');
   });
+
+  it('should fall back to the first project whether the selected one is not a number', async () => {
+    const view = await openReleaseModal();
+    const projectBlock = findBlockByActionId(
+      view.blocks,
+      'release-select-project-action',
+    ) as InputBlock;
+
+    // When Slack sends a project id Homer cannot parse
+    const response = await postBlockActions({
+      actions: [{ action_id: 'release-select-project-action' }],
+      type: 'block_actions',
+      view: {
+        ...view,
+        id: 'viewId',
+        state: {
+          values: {
+            [projectBlock.block_id as string]: {
+              'release-select-project-action': {
+                selected_option: { value: 'not-a-number' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+
+    // Then the modal is rebuilt on the first project instead of crashing
+    const updatedView = getUpdatedView(3) as ViewsUpdateArguments['view'];
+
+    expect(
+      (
+        findBlockByActionId(updatedView.blocks, 'release-select-project-action')
+          ?.element as StaticSelect
+      ).initial_option?.value,
+    ).toEqual(`${firstProject.id}`);
+    expect(
+      findBlockByActionId(updatedView.blocks, 'release-tag-action')?.block_id,
+    ).toEqual('release-tag-block-1148-stable-20200101-1000');
+  });
+
+  it('should log an unknown block action, reading the project from the view state', async () => {
+    const view = await openReleaseModal();
+    const projectBlock = findBlockByActionId(
+      view.blocks,
+      'release-select-project-action',
+    ) as InputBlock;
+    const projectOptions = (projectBlock.element as StaticSelect)
+      .options as StaticSelect['options'];
+
+    const response = await postBlockActions({
+      actions: [{ action_id: 'release-unknown-action' }],
+      type: 'block_actions',
+      view: {
+        ...view,
+        id: 'viewId',
+        state: {
+          values: {
+            [projectBlock.block_id as string]: {
+              'release-select-project-action': {
+                selected_option: projectOptions?.[1],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.status).toEqual(HTTP_STATUS_OK);
+
+    // The release config is looked up on the project selected in the state,
+    // whatever the block it has been read from.
+    expect(ConfigHelper.getProjectReleaseConfig).toHaveBeenCalledWith(
+      secondProject.id,
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      new Error('Unknown block action: release-unknown-action'),
+    );
+  });
 });

--- a/src/changelog/buildChangelogModalView.ts
+++ b/src/changelog/buildChangelogModalView.ts
@@ -7,6 +7,17 @@ import type { GitlabProjectDetails } from '@/core/typings/GitlabProject';
 import type { SlackOption } from '@/core/typings/SlackOption';
 import { slackifyText } from '@/core/utils/slackifyText';
 import { truncateProjectPath } from '@/core/utils/truncateProjectPath';
+import {
+  buildChangelogMarkdownBlockId,
+  buildChangelogReleaseTagBlockId,
+  CHANGELOG_MARKDOWN_ACTION_ID,
+  CHANGELOG_PREVIEW_BLOCK_ID,
+  CHANGELOG_PREVIEW_TITLE_BLOCK_ID,
+  CHANGELOG_PROJECT_BLOCK_ID,
+  CHANGELOG_RELEASE_TAG_INFO_BLOCK_ID,
+  CHANGELOG_SELECT_PROJECT_ACTION_ID,
+  CHANGELOG_SELECT_RELEASE_TAG_ACTION_ID,
+} from './changelogModalBlockIds';
 
 interface ChangelogModalData {
   channelId?: string;
@@ -76,6 +87,15 @@ export async function buildChangelogModalView({
     value: name,
   })) as SlackOption[];
 
+  const projectInitialOption =
+    projectOptions.find(({ value }) => value === `${projectId}`) ??
+    projectOptions[0];
+
+  const previousReleaseInitialOption =
+    previousReleaseOptions.find(
+      ({ value }) => value === previousReleaseTagName,
+    ) ?? previousReleaseOptions[0];
+
   return {
     type: 'modal',
     callback_id: 'changelog-modal',
@@ -91,13 +111,13 @@ export async function buildChangelogModalView({
     blocks: [
       {
         type: 'input',
-        block_id: 'changelog-project-block',
+        block_id: CHANGELOG_PROJECT_BLOCK_ID,
         dispatch_action: true,
         element: {
           type: 'static_select',
-          action_id: 'changelog-select-project-action',
+          action_id: CHANGELOG_SELECT_PROJECT_ACTION_ID,
           options: projectOptions,
-          initial_option: projectOptions?.[0],
+          initial_option: projectInitialOption,
           placeholder: {
             type: 'plain_text',
             text: 'Select the project',
@@ -112,12 +132,12 @@ export async function buildChangelogModalView({
         ? [
             {
               type: 'input',
-              block_id: 'changelog-release-tag-block',
+              block_id: buildChangelogReleaseTagBlockId(projectId),
               dispatch_action: true,
               element: {
                 type: 'static_select',
-                action_id: 'changelog-select-release-tag-action',
-                initial_option: previousReleaseOptions[0],
+                action_id: CHANGELOG_SELECT_RELEASE_TAG_ACTION_ID,
+                initial_option: previousReleaseInitialOption,
                 options: previousReleaseOptions,
                 placeholder: {
                   type: 'plain_text',
@@ -131,7 +151,7 @@ export async function buildChangelogModalView({
             },
             {
               type: 'context',
-              block_id: 'changelog-release-tag-info-block',
+              block_id: CHANGELOG_RELEASE_TAG_INFO_BLOCK_ID,
               elements: [
                 {
                   type: 'plain_text',
@@ -158,7 +178,7 @@ export async function buildChangelogModalView({
           ],
       {
         type: 'section',
-        block_id: 'changelog-preview-title-block',
+        block_id: CHANGELOG_PREVIEW_TITLE_BLOCK_ID,
         text: {
           type: 'mrkdwn',
           text: '*Preview*',
@@ -166,7 +186,7 @@ export async function buildChangelogModalView({
       },
       {
         type: 'section',
-        block_id: 'changelog-preview-block',
+        block_id: CHANGELOG_PREVIEW_BLOCK_ID,
         text: {
           type: 'mrkdwn',
           text: changelog
@@ -179,13 +199,17 @@ export async function buildChangelogModalView({
       },
       changelog && {
         type: 'input',
-        block_id: 'changelog-markdown-block',
+        block_id: buildChangelogMarkdownBlockId(
+          projectId,
+          previousReleaseTagName,
+        ),
         label: {
           type: 'plain_text',
           text: 'Markdown',
         },
         element: {
           type: 'plain_text_input',
+          action_id: CHANGELOG_MARKDOWN_ACTION_ID,
           multiline: true,
           initial_value: changelog,
         },

--- a/src/changelog/changelogModalBlockIds.ts
+++ b/src/changelog/changelogModalBlockIds.ts
@@ -1,0 +1,35 @@
+import { buildBlockId } from '@/core/utils/buildBlockId';
+
+/**
+ * Action ids are the stable contract of the changelog modal: block ids of the
+ * inputs are rotated so that Slack rebuilds them instead of preserving their
+ * previous value, hence the view state must always be read by action id.
+ */
+export const CHANGELOG_SELECT_PROJECT_ACTION_ID =
+  'changelog-select-project-action';
+export const CHANGELOG_SELECT_RELEASE_TAG_ACTION_ID =
+  'changelog-select-release-tag-action';
+export const CHANGELOG_MARKDOWN_ACTION_ID = 'changelog-markdown-action';
+
+/** Stable: the user selection must be preserved, and it is a splice anchor. */
+export const CHANGELOG_PROJECT_BLOCK_ID = 'changelog-project-block';
+
+/** Stable: holds no state, and it is a splice anchor. */
+export const CHANGELOG_RELEASE_TAG_INFO_BLOCK_ID =
+  'changelog-release-tag-info-block';
+
+export const CHANGELOG_PREVIEW_TITLE_BLOCK_ID = 'changelog-preview-title-block';
+export const CHANGELOG_PREVIEW_BLOCK_ID = 'changelog-preview-block';
+
+/** Rotates whenever the available release tags change. */
+export function buildChangelogReleaseTagBlockId(projectId: number): string {
+  return buildBlockId('changelog-release-tag-block', projectId);
+}
+
+/** Rotates whenever the generated changelog changes. */
+export function buildChangelogMarkdownBlockId(
+  projectId: number,
+  releaseTagName: string | undefined,
+): string {
+  return buildBlockId('changelog-markdown-block', projectId, releaseTagName);
+}

--- a/src/changelog/utils/updateChangelog.ts
+++ b/src/changelog/utils/updateChangelog.ts
@@ -3,13 +3,19 @@ import { slackBotWebClient } from '@/core/services/slack';
 import type { BlockActionsPayload } from '@/core/typings/BlockActionPayload';
 import type { SlackOption } from '@/core/typings/SlackOption';
 import { cleanViewState } from '@/core/utils/cleanViewState';
+import { getViewStateValue } from '@/core/utils/getViewStateValue';
 import { buildChangelogModalView } from '../buildChangelogModalView';
+import {
+  CHANGELOG_RELEASE_TAG_INFO_BLOCK_ID,
+  CHANGELOG_SELECT_PROJECT_ACTION_ID,
+  CHANGELOG_SELECT_RELEASE_TAG_ACTION_ID,
+} from '../changelogModalBlockIds';
 
 export async function updateChangelog(payload: BlockActionsPayload) {
-  const { blocks, callback_id, id, state, submit, title, type } = payload.view;
+  const { blocks, callback_id, id, submit, title, type } = payload.view;
   const currentView = { blocks, callback_id, submit, title, type };
   const releaseTagInfoBlockIndex = blocks.findIndex(
-    (block) => block.block_id === 'changelog-release-tag-info-block'
+    (block) => block.block_id === CHANGELOG_RELEASE_TAG_INFO_BLOCK_ID,
   );
 
   if (releaseTagInfoBlockIndex !== -1) {
@@ -26,20 +32,26 @@ export async function updateChangelog(payload: BlockActionsPayload) {
   });
 
   const projectId = parseInt(
-    state.values['changelog-project-block']?.['changelog-select-project-action']
-      ?.selected_option?.value,
-    10
+    getViewStateValue(payload.view, CHANGELOG_SELECT_PROJECT_ACTION_ID)
+      ?.selected_option?.value as string,
+    10,
   );
 
-  const releaseTagName =
-    state.values['changelog-release-tag-block']?.[
-      'changelog-select-release-tag-action'
-    ]?.selected_option?.value;
+  const releaseTagName = getViewStateValue(
+    payload.view,
+    CHANGELOG_SELECT_RELEASE_TAG_ACTION_ID,
+  )?.selected_option?.value;
+
+  const projectBlock = blocks.find(
+    (block) =>
+      ((block as InputBlock).element as StaticSelect)?.action_id ===
+      CHANGELOG_SELECT_PROJECT_ACTION_ID,
+  ) as InputBlock | undefined;
 
   const viewPromise = buildChangelogModalView({
     projectId,
-    projectOptions: ((blocks[0] as InputBlock).element as StaticSelect)
-      .options as SlackOption[],
+    projectOptions: (projectBlock?.element as StaticSelect)
+      ?.options as SlackOption[],
     releaseTagName,
   });
 

--- a/src/changelog/utils/updateChangelogProject.ts
+++ b/src/changelog/utils/updateChangelogProject.ts
@@ -1,11 +1,12 @@
 import type { BlockActionsPayload } from '@/core/typings/BlockActionPayload';
 import { cleanViewState } from '@/core/utils/cleanViewState';
+import { CHANGELOG_PROJECT_BLOCK_ID } from '../changelogModalBlockIds';
 import { updateChangelog } from './updateChangelog';
 
 export async function updateChangelogProject(payload: BlockActionsPayload) {
   const { blocks } = payload.view;
   const projectBlockIndex = blocks.findIndex(
-    (block) => block.block_id === 'changelog-project-block'
+    (block) => block.block_id === CHANGELOG_PROJECT_BLOCK_ID,
   );
 
   blocks.splice(projectBlockIndex + 1);

--- a/src/core/utils/buildBlockId.ts
+++ b/src/core/utils/buildBlockId.ts
@@ -1,0 +1,30 @@
+import { createHash } from 'node:crypto';
+
+/** Slack rejects any `block_id` longer than 255 characters. */
+const MAX_BLOCK_ID_LENGTH = 255;
+
+/**
+ * Builds a `block_id` that changes as soon as one of `parts` changes.
+ *
+ * Slack preserves the state of an input block across `views.update` calls as
+ * long as its `block_id` and `action_id` remain the same, ignoring the new
+ * `initial_value` / `initial_option`. Giving a block an id derived from the
+ * data it displays is the documented way to force Slack to rebuild it.
+ *
+ * @see https://docs.slack.dev/reference/methods/views.update/
+ */
+export function buildBlockId(
+  prefix: string,
+  ...parts: (string | number | undefined)[]
+): string {
+  const blockId = [
+    prefix,
+    ...parts.map((part) => `${part ?? 'none'}`.replace(/[^\w.-]/g, '_')),
+  ].join('-');
+
+  if (blockId.length <= MAX_BLOCK_ID_LENGTH) {
+    return blockId;
+  }
+  // Hashing instead of truncating prevents collisions between long values.
+  return `${prefix}-${createHash('sha1').update(blockId).digest('hex').slice(0, 16)}`;
+}

--- a/src/core/utils/getViewStateValue.ts
+++ b/src/core/utils/getViewStateValue.ts
@@ -1,0 +1,32 @@
+export interface ViewStateValue {
+  type?: string;
+  value?: string | null;
+  selected_option?: { value: string } | null;
+  [key: string]: unknown;
+}
+
+interface ViewWithState {
+  state?: { values?: Record<string, Record<string, ViewStateValue>> };
+}
+
+/**
+ * Returns the state value of the element identified by `actionId`, whatever the
+ * block it belongs to.
+ *
+ * Block ids of the modals are rotated on purpose, so that Slack rebuilds the
+ * inputs instead of preserving their previous value. They cannot be relied on
+ * to read the view state, whereas action ids are stable.
+ */
+export function getViewStateValue(
+  view: ViewWithState | undefined,
+  actionId: string,
+): ViewStateValue | undefined {
+  const values = view?.state?.values;
+
+  if (values === undefined) {
+    return undefined;
+  }
+  return Object.values(values).find(
+    (blockValues) => blockValues?.[actionId] !== undefined,
+  )?.[actionId];
+}

--- a/src/release/commands/create/utils/createRelease.ts
+++ b/src/release/commands/create/utils/createRelease.ts
@@ -8,28 +8,34 @@ import {
 import { fetchSlackUserFromId } from '@/core/services/slack';
 import type { DataRelease } from '@/core/typings/Data';
 import type { ModalViewSubmissionPayload } from '@/core/typings/ModalViewSubmissionPayload';
+import { getViewStateValue } from '@/core/utils/getViewStateValue';
 import getReleaseOptions from '@/release/releaseOptions';
 import ConfigHelper from '../../../utils/ConfigHelper';
+import {
+  RELEASE_SELECT_PREVIOUS_TAG_ACTION_ID,
+  RELEASE_SELECT_PROJECT_ACTION_ID,
+  RELEASE_TAG_ACTION_ID,
+} from '../viewBuilders/releaseModalBlockIds';
 import { waitForReadinessAndStartRelease } from './waitForReadinessAndStartRelease';
 
 export async function createRelease(
   payload: ModalViewSubmissionPayload,
 ): Promise<void> {
   const { user, view } = payload;
-  const { values } = view.state;
 
   const projectId = parseInt(
-    values['release-project-block']['release-select-project-action']
-      .selected_option.value,
+    getViewStateValue(view, RELEASE_SELECT_PROJECT_ACTION_ID)?.selected_option
+      ?.value as string,
     10,
   );
 
-  const releaseTagName: string =
-    values['release-tag-block']['release-tag-action'].value;
+  const releaseTagName = getViewStateValue(view, RELEASE_TAG_ACTION_ID)
+    ?.value as string;
 
-  const previousReleaseTagName: string | undefined =
-    values['release-previous-tag-block']?.['release-select-previous-tag-action']
-      ?.selected_option.value;
+  const previousReleaseTagName: string | undefined = getViewStateValue(
+    view,
+    RELEASE_SELECT_PREVIOUS_TAG_ACTION_ID,
+  )?.selected_option?.value;
 
   const { releaseManager } =
     await ConfigHelper.getProjectReleaseConfig(projectId);

--- a/src/release/commands/create/utils/updateReleaseChangelog.ts
+++ b/src/release/commands/create/utils/updateReleaseChangelog.ts
@@ -2,12 +2,13 @@ import { slackBotWebClient } from '@/core/services/slack';
 import type { BlockActionsPayload } from '@/core/typings/BlockActionPayload';
 import { cleanViewState } from '@/core/utils/cleanViewState';
 import { buildReleaseModalView } from '../viewBuilders/buildReleaseModalView';
+import { RELEASE_PREVIOUS_TAG_INFO_BLOCK_ID } from '../viewBuilders/releaseModalBlockIds';
 import { addLoaderToReleaseModal } from './addLoaderToReleaseModal';
 
 export async function updateReleaseChangelog({ view }: BlockActionsPayload) {
   const { blocks, id } = view;
   const previousReleaseInfoBlockIndex = blocks.findIndex(
-    (block) => block.block_id === 'release-previous-tag-info-block'
+    (block) => block.block_id === RELEASE_PREVIOUS_TAG_INFO_BLOCK_ID,
   );
 
   if (previousReleaseInfoBlockIndex !== -1) {

--- a/src/release/commands/create/utils/updateReleaseProject.ts
+++ b/src/release/commands/create/utils/updateReleaseProject.ts
@@ -2,12 +2,13 @@ import { slackBotWebClient } from '@/core/services/slack';
 import type { BlockActionsPayload } from '@/core/typings/BlockActionPayload';
 import { cleanViewState } from '@/core/utils/cleanViewState';
 import { buildReleaseModalView } from '../viewBuilders/buildReleaseModalView';
+import { RELEASE_PROJECT_BLOCK_ID } from '../viewBuilders/releaseModalBlockIds';
 import { addLoaderToReleaseModal } from './addLoaderToReleaseModal';
 
 export async function updateReleaseProject({ view }: BlockActionsPayload) {
   const { blocks, id } = view;
   const projectBlockIndex = blocks.findIndex(
-    (block) => block.block_id === 'release-project-block'
+    (block) => block.block_id === RELEASE_PROJECT_BLOCK_ID,
   );
 
   blocks.splice(projectBlockIndex + 1);

--- a/src/release/commands/create/viewBuilders/buildReleaseModalView.ts
+++ b/src/release/commands/create/viewBuilders/buildReleaseModalView.ts
@@ -7,12 +7,24 @@ import type {
 } from '@slack/web-api';
 import { generateChangelog } from '@/changelog/utils/generateChangelog';
 import { fetchProjectById, fetchProjectTags } from '@/core/services/gitlab';
+import { logger } from '@/core/services/logger';
 import type { BlockActionView } from '@/core/typings/BlockActionPayload';
 import type { SlackOption } from '@/core/typings/SlackOption';
+import { getViewStateValue } from '@/core/utils/getViewStateValue';
 import { slackifyText } from '@/core/utils/slackifyText';
 import { truncateProjectPath } from '@/core/utils/truncateProjectPath';
 import getReleaseOptions from '@/release/releaseOptions';
 import ConfigHelper from '../../../utils/ConfigHelper';
+import {
+  buildPreviousReleaseTagBlockId,
+  buildReleaseTagBlockId,
+  RELEASE_CHANGELOG_BLOCK_ID,
+  RELEASE_PREVIOUS_TAG_INFO_BLOCK_ID,
+  RELEASE_PROJECT_BLOCK_ID,
+  RELEASE_SELECT_PREVIOUS_TAG_ACTION_ID,
+  RELEASE_SELECT_PROJECT_ACTION_ID,
+  RELEASE_TAG_ACTION_ID,
+} from './releaseModalBlockIds';
 
 interface ReleaseModalData {
   channelId?: string;
@@ -27,22 +39,39 @@ export async function buildReleaseModalView({
   let projectId: number | undefined;
   let projectOptions: SlackOption[] | undefined;
 
+  // ⚠️ Everything read from `view` must be read synchronously: the callers
+  // start this build before mutating `view.blocks` to display the loader.
   if (view !== undefined) {
-    const { blocks, state } = view;
+    const { blocks } = view;
 
-    previousReleaseTagName =
-      state.values['release-previous-tag-block']?.[
-        'release-select-previous-tag-action'
-      ]?.selected_option?.value;
+    previousReleaseTagName = getViewStateValue(
+      view,
+      RELEASE_SELECT_PREVIOUS_TAG_ACTION_ID,
+    )?.selected_option?.value;
 
-    projectId = parseInt(
-      state.values['release-project-block']?.['release-select-project-action']
-        ?.selected_option?.value,
-      10,
-    );
+    const selectedProjectId = getViewStateValue(
+      view,
+      RELEASE_SELECT_PROJECT_ACTION_ID,
+    )?.selected_option?.value;
 
-    projectOptions = ((blocks[0] as InputBlock).element as StaticSelect)
-      .options as SlackOption[];
+    projectId =
+      selectedProjectId !== undefined
+        ? parseInt(selectedProjectId, 10)
+        : undefined;
+
+    if (projectId !== undefined && Number.isNaN(projectId)) {
+      projectId = undefined;
+    }
+
+    const projectBlock = blocks.find(
+      (block) =>
+        ((block as InputBlock).element as StaticSelect)?.action_id ===
+        RELEASE_SELECT_PROJECT_ACTION_ID,
+    ) as InputBlock | undefined;
+
+    projectOptions = (projectBlock?.element as StaticSelect)?.options as
+      | SlackOption[]
+      | undefined;
   }
 
   if (projectOptions === undefined && channelId !== undefined) {
@@ -110,7 +139,15 @@ export async function buildReleaseModalView({
     previousReleaseTagName !== undefined &&
     previousReleaseTag === undefined
   ) {
-    throw new Error(`Previous release tag ${previousReleaseTagName} not found`);
+    // Happens when a tag selected on another project is carried over. Throwing
+    // here would leave the modal stuck on its loader, so fall back to the
+    // latest release tag of the selected project instead.
+    logger.error(
+      new Error(
+        `Previous release tag ${previousReleaseTagName} not found in project ${projectId}`,
+      ),
+    );
+    previousReleaseTagName = undefined;
   }
 
   if (tags.length > 0 && previousReleaseTagName === undefined) {
@@ -129,6 +166,15 @@ export async function buildReleaseModalView({
     value: name,
   })) as SlackOption[];
 
+  const projectInitialOption =
+    projectOptions.find(({ value }) => value === `${projectId}`) ??
+    projectOptions[0];
+
+  const previousReleaseInitialOption =
+    previousReleaseOptions.find(
+      ({ value }) => value === previousReleaseTagName,
+    ) ?? previousReleaseOptions[0];
+
   return {
     type: 'modal',
     callback_id: 'release-create-modal',
@@ -144,12 +190,12 @@ export async function buildReleaseModalView({
     blocks: [
       {
         type: 'input',
-        block_id: 'release-project-block',
+        block_id: RELEASE_PROJECT_BLOCK_ID,
         dispatch_action: true,
         element: {
           type: 'static_select',
-          action_id: 'release-select-project-action',
-          initial_option: projectOptions?.[0],
+          action_id: RELEASE_SELECT_PROJECT_ACTION_ID,
+          initial_option: projectInitialOption,
           options: projectOptions,
           placeholder: {
             type: 'plain_text',
@@ -163,10 +209,10 @@ export async function buildReleaseModalView({
       },
       {
         type: 'input',
-        block_id: 'release-tag-block',
+        block_id: buildReleaseTagBlockId(projectId, previousReleaseTagName),
         element: {
           type: 'plain_text_input',
-          action_id: 'release-tag-action',
+          action_id: RELEASE_TAG_ACTION_ID,
           initial_value: releaseTagManager.createReleaseTag(
             previousReleaseTagName,
           ),
@@ -180,12 +226,12 @@ export async function buildReleaseModalView({
         ? [
             {
               type: 'input',
-              block_id: 'release-previous-tag-block',
+              block_id: buildPreviousReleaseTagBlockId(projectId),
               dispatch_action: true,
               element: {
                 type: 'static_select',
-                action_id: 'release-select-previous-tag-action',
-                initial_option: previousReleaseOptions[0],
+                action_id: RELEASE_SELECT_PREVIOUS_TAG_ACTION_ID,
+                initial_option: previousReleaseInitialOption,
                 options: previousReleaseOptions,
                 placeholder: {
                   type: 'plain_text',
@@ -199,7 +245,7 @@ export async function buildReleaseModalView({
             },
             {
               type: 'context',
-              block_id: 'release-previous-tag-info-block',
+              block_id: RELEASE_PREVIOUS_TAG_INFO_BLOCK_ID,
               elements: [
                 {
                   type: 'plain_text',
@@ -233,7 +279,7 @@ export async function buildReleaseModalView({
       },
       {
         type: 'section',
-        block_id: 'release-changelog-block',
+        block_id: RELEASE_CHANGELOG_BLOCK_ID,
         text: {
           type: 'mrkdwn',
           text: changelog

--- a/src/release/commands/create/viewBuilders/releaseModalBlockIds.ts
+++ b/src/release/commands/create/viewBuilders/releaseModalBlockIds.ts
@@ -1,0 +1,33 @@
+import { buildBlockId } from '@/core/utils/buildBlockId';
+
+/**
+ * Action ids are the stable contract of the release modal: block ids of the
+ * inputs are rotated so that Slack rebuilds them instead of preserving their
+ * previous value, hence the view state must always be read by action id.
+ */
+export const RELEASE_SELECT_PROJECT_ACTION_ID = 'release-select-project-action';
+export const RELEASE_TAG_ACTION_ID = 'release-tag-action';
+export const RELEASE_SELECT_PREVIOUS_TAG_ACTION_ID =
+  'release-select-previous-tag-action';
+
+/** Stable: the user selection must be preserved, and it is a splice anchor. */
+export const RELEASE_PROJECT_BLOCK_ID = 'release-project-block';
+
+/** Stable: holds no state, and it is a splice anchor. */
+export const RELEASE_PREVIOUS_TAG_INFO_BLOCK_ID =
+  'release-previous-tag-info-block';
+
+export const RELEASE_CHANGELOG_BLOCK_ID = 'release-changelog-block';
+
+/** Rotates whenever the release tag suggestion changes. */
+export function buildReleaseTagBlockId(
+  projectId: number,
+  previousReleaseTagName: string | undefined,
+): string {
+  return buildBlockId('release-tag-block', projectId, previousReleaseTagName);
+}
+
+/** Rotates whenever the available release tags change. */
+export function buildPreviousReleaseTagBlockId(projectId: number): string {
+  return buildBlockId('release-previous-tag-block', projectId);
+}

--- a/src/release/releaseBlockActionsHandler.ts
+++ b/src/release/releaseBlockActionsHandler.ts
@@ -2,12 +2,14 @@ import { logger } from '@/core/services/logger';
 import type { BlockActionsPayload } from '@/core/typings/BlockActionPayload';
 import type { ButtonAction } from '@/core/typings/ButtonAction';
 import type { StaticSelectAction } from '@/core/typings/StaticSelectAction';
+import { getViewStateValue } from '@/core/utils/getViewStateValue';
 import { cancelReleaseButtonHandler } from '@/release/commands/cancel/cancelReleaseButtonHandler';
 import { displayReleaseChangelog } from '@/release/commands/changelog/displayReleaseChangelog';
 import { endReleaseButtonHandler } from '@/release/commands/end/endReleaseButtonHandler';
 import { selectReleaseToCancel } from './commands/cancel/selectReleaseToCancel';
 import { updateReleaseChangelog } from './commands/create/utils/updateReleaseChangelog';
 import { updateReleaseProject } from './commands/create/utils/updateReleaseProject';
+import { RELEASE_SELECT_PROJECT_ACTION_ID } from './commands/create/viewBuilders/releaseModalBlockIds';
 import { selectReleaseToEnd } from './commands/end/selectReleaseToEnd';
 import getReleaseOptions from './releaseOptions';
 import ConfigHelper from './utils/ConfigHelper';
@@ -42,11 +44,9 @@ export async function releaseBlockActionsHandler(
           return cancelReleaseButtonHandler(payload, action as ButtonAction);
 
         default: {
-          const { state } = payload.view;
           const projectId = parseInt(
-            state.values['release-project-block']?.[
-              'release-select-project-action'
-            ]?.selected_option?.value,
+            getViewStateValue(payload.view, RELEASE_SELECT_PROJECT_ACTION_ID)
+              ?.selected_option?.value as string,
             10,
           );
           const { releaseManager } =

--- a/src/release/releaseOptions.ts
+++ b/src/release/releaseOptions.ts
@@ -8,6 +8,7 @@ import {
 import { logger } from '@/core/services/logger';
 import { slackBotWebClient } from '@/core/services/slack';
 import { cleanViewState } from '@/core/utils/cleanViewState';
+import { getViewStateValue } from '@/core/utils/getViewStateValue';
 import { slackifyChangelog } from '@/release/commands/create/utils/slackifyChangelog';
 import { addLoaderToReleaseModal } from './commands/create/utils/addLoaderToReleaseModal';
 import type { ReleaseOptions } from './typings/ReleaseManager';
@@ -19,6 +20,7 @@ export default function getReleaseOptions(): ReleaseOptions {
     slack: {
       addLoaderToReleaseModal,
       cleanViewState,
+      getViewStateValue,
       slackifyChangelog,
       webClient: slackBotWebClient,
     },

--- a/src/release/releaseViewSubmissionHandler.ts
+++ b/src/release/releaseViewSubmissionHandler.ts
@@ -2,8 +2,10 @@ import type { Request, Response } from 'express';
 import { HTTP_STATUS_NO_CONTENT } from '@/constants';
 import { logger } from '@/core/services/logger';
 import type { ModalViewSubmissionPayload } from '@/core/typings/ModalViewSubmissionPayload';
+import { getViewStateValue } from '@/core/utils/getViewStateValue';
 import { createRelease } from './commands/create/utils/createRelease';
 import { buildReleaseModalView } from './commands/create/viewBuilders/buildReleaseModalView';
+import { RELEASE_TAG_ACTION_ID } from './commands/create/viewBuilders/releaseModalBlockIds';
 
 export async function releaseViewSubmissionHandler(
   req: Request,
@@ -15,9 +17,8 @@ export async function releaseViewSubmissionHandler(
   switch (callback_id) {
     case 'release-create-modal': {
       const { view } = payload;
-      const { state } = view;
 
-      if (state.values['release-tag-block'] === undefined) {
+      if (getViewStateValue(view, RELEASE_TAG_ACTION_ID) === undefined) {
         res.json({
           response_action: 'update',
           view: await buildReleaseModalView({ view }),

--- a/src/release/typings/ReleaseManager.ts
+++ b/src/release/typings/ReleaseManager.ts
@@ -17,6 +17,7 @@ import type { GitlabDeploymentHook } from '@/core/typings/GitlabDeploymentHook';
 import type { SlackOption } from '@/core/typings/SlackOption';
 import type { StaticSelectAction } from '@/core/typings/StaticSelectAction';
 import type { cleanViewState } from '@/core/utils/cleanViewState';
+import type { getViewStateValue } from '@/core/utils/getViewStateValue';
 import type { slackifyChangelog } from '@/release/commands/create/utils/slackifyChangelog';
 import type { addLoaderToReleaseModal } from '../commands/create/utils/addLoaderToReleaseModal';
 import type { ReleaseStateUpdate } from './ReleaseStateUpdate';
@@ -38,13 +39,14 @@ export interface ReleaseOptions {
   release: {
     getReleaseManager: (managerName: string) => ReleaseManager | undefined;
     getReleaseTagManager: (
-      tagManagerName: string
+      tagManagerName: string,
     ) => ReleaseTagManager | undefined;
   };
   slack: {
     slackifyChangelog: typeof slackifyChangelog;
     addLoaderToReleaseModal: typeof addLoaderToReleaseModal;
     cleanViewState: typeof cleanViewState;
+    getViewStateValue: typeof getViewStateValue;
     webClient: typeof slackBotWebClient;
   };
   logger: typeof logger;
@@ -54,26 +56,26 @@ export interface ReleaseManager {
   blockActionsHandler?(
     payload: BlockActionsPayload,
     action: StaticSelectAction,
-    options?: ReleaseOptions
+    options?: ReleaseOptions,
   ): Promise<void>;
   buildReleaseModalView?(
     releaseModalData: ReleaseModalData,
-    options?: ReleaseOptions
+    options?: ReleaseOptions,
   ): Promise<View>;
   filterChangelog?(
     commit: GitlabCommit,
     viewState: any,
-    options?: ReleaseOptions
+    options?: ReleaseOptions,
   ): boolean;
   filterReleasesToClean?(
     newRelease: DataRelease,
     oldReleases: DataRelease[],
-    options?: ReleaseOptions
+    options?: ReleaseOptions,
   ): DataRelease[];
   getReleaseStateUpdate(
     release: DataRelease,
     deploymentHook?: GitlabDeploymentHook,
-    options?: ReleaseOptions
+    options?: ReleaseOptions,
   ): Promise<ReleaseStateUpdate[]>;
   /**
    * Should be used to check whether release preconditions are ok.
@@ -83,6 +85,6 @@ export interface ReleaseManager {
   isReadyToRelease(
     release: DataRelease,
     mainBranchPipelineId: number,
-    options?: ReleaseOptions
+    options?: ReleaseOptions,
   ): Promise<boolean>;
 }


### PR DESCRIPTION
Fixes #180

## Problem

Switching project in the `/homer release` combo box left the **Release tag** and **Previous release tag** fields showing the numbers of the previously selected project.

## Root cause

Slack preserves the state of an input block across `views.update` calls as long as its `block_id` **and** `action_id` stay the same, and **ignores the new `initial_value` / `initial_option`** for those blocks ([views.update](https://docs.slack.dev/reference/methods/views.update/), [bolt-python#572](https://github.com/slackapi/bolt-python/issues/572), [bolt-python#1064](https://github.com/slackapi/bolt-python/issues/1064)).

The existing workaround — truncate `view.blocks`, `cleanViewState`, push a `:loader:` interim update, then rebuild — only resets the *server-side* payload state used to recompute the view. The rebuilt view was already correct on the wire (the existing test asserts it); the Slack client simply kept rendering the retained values because the block ids never changed.

## Fix

- Rotate the `block_id` of the inputs that depend on the selected project, which is the documented way to force Slack to rebuild them:
  - `release-tag-block-<projectId>-<previousReleaseTagName>`
  - `release-previous-tag-block-<projectId>`
  - the project select keeps a stable id, so the user's own choice is preserved.
- Read the view state by `action_id` instead of `block_id` (new `getViewStateValue` util), since block ids are not stable anymore.
- Select the current option instead of `options[0]` in both combo boxes.
- Replace the `Previous release tag ... not found` **throw** with a fallback to the latest tag: it used to abort the rebuild and leave the modal stuck on its loader.
- Fix a latent `parseInt(undefined) === NaN` that made the `projectId === undefined` fallback dead code.

`/homer changelog` is a near-clone and had the same defect, including the Markdown textarea, which kept the changelog of the previous project and had no explicit `action_id`. It gets the same treatment.

## Tests

- `__tests__/release/switchReleaseProject.test.ts` — two projects in one channel, switch project, assert the rebuilt modal shows the new project's numbers, that the project select stays on the chosen project, and that the block ids rotated. Verified this **fails on `main`** (`Expected "2222" / Received "1148"`).
- `__tests__/core/utils/getViewStateValue.test.ts` — unit tests for the new util.
- Existing suite updated for the rotated ids: 121 tests pass, `tsc` and `eslint` clean.

## Notes for reviewers

- **Behaviour change:** because the release-tag block id also keys on the previous tag, hand-editing the release tag and *then* changing the previous tag now discards that edit and re-suggests `createReleaseTag(newPrevious)`. That is consistent (the suggestion derives from the previous tag) but differs from today. Happy to key on `projectId` alone if you would rather keep manual edits sticky.
- **Plugin contract:** block ids of the release modal must no longer be relied on; action ids are the stable contract. Documented in `PLUGIN_RELEASE.md`, and `getViewStateValue` is exposed through `ReleaseOptions.slack`. No in-tree plugin is affected.
- **Not addressed here:** `views.update` passes no `hash`, so rapidly switching projects can still race (follow-up); and `fetchProjectTags` is `per_page=100` unpaginated with a `.slice(0, 5)`, so busy repos can lose older release tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
